### PR TITLE
Refactor app package to use relative imports

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -22,20 +22,20 @@ from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 # Import models and routes
-from app import models
-from app.routes import routes
-from app.routes.chat import chat
+from . import models
+from .routes import routes
+from .routes.chat import chat
 # Import blueprints
-from app.routes.cours import cours_bp
-from app.routes.evaluation import evaluation_bp
-from app.routes.gestion_programme import gestion_programme_bp
-from app.routes.plan_cadre import plan_cadre_bp
-from app.routes.plan_de_cours import plan_de_cours_bp
-from app.routes.programme import programme_bp
-from app.routes.settings import settings_bp
-from app.routes.system import system_bp
-from app.routes.ocr_routes import ocr_bp
-from app.routes.grilles import grille_bp
+from .routes.cours import cours_bp
+from .routes.evaluation import evaluation_bp
+from .routes.gestion_programme import gestion_programme_bp
+from .routes.plan_cadre import plan_cadre_bp
+from .routes.plan_de_cours import plan_de_cours_bp
+from .routes.programme import programme_bp
+from .routes.settings import settings_bp
+from .routes.system import system_bp
+from .routes.ocr_routes import ocr_bp
+from .routes.grilles import grille_bp
 
 # Import version
 from config.version import __version__
@@ -145,7 +145,7 @@ def create_app(testing=False):
     bcrypt.init_app(app)
     limiter.init_app(app)
 
-    from app.models import User  # Import your User model
+    from .models import User  # Import your User model
 
     @login_manager.user_loader
     def load_user(user_id):
@@ -272,7 +272,7 @@ def create_app(testing=False):
                     logger.warning(
                         "⚠️ Table 'backup_config' introuvable, la planification des sauvegardes est ignorée.")
 
-                from app.init.prompt_settings import init_plan_de_cours_prompts
+                from .init.prompt_settings import init_plan_de_cours_prompts
                 init_plan_de_cours_prompts()
 
                 # Perform WAL checkpoint
@@ -322,7 +322,7 @@ def create_app(testing=False):
         with app.app_context():
             # Always create missing tables; create_all() will do nothing if tables already exist.
             db.create_all()
-            from app.models import User  # Ensure the User model is imported
+            from .models import User  # Ensure the User model is imported
 
             # Check if an admin user exists; if not, create one.
             if not User.query.filter_by(role='admin').first():

--- a/src/app/forms.py
+++ b/src/app/forms.py
@@ -26,7 +26,7 @@ from wtforms import widgets
 from wtforms.validators import DataRequired, InputRequired, NumberRange, Optional, Length, EqualTo, Email, URL
 from wtforms.widgets import ListWidget, CheckboxInput
 
-from app.models import User
+from .models import User
 from utils.openai_pricing import get_all_models
 
 # Liste des régions disponibles

--- a/src/app/init/prompt_settings.py
+++ b/src/app/init/prompt_settings.py
@@ -2,8 +2,8 @@
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 
-from app import db, logger
-from app.models import PlanDeCoursPromptSettings
+from .. import db, logger
+from ..models import PlanDeCoursPromptSettings
 
 
 def init_plan_de_cours_prompts():

--- a/src/app/routes/chat.py
+++ b/src/app/routes/chat.py
@@ -5,8 +5,8 @@ from flask import Blueprint, render_template, request, current_app, Response, st
 from flask_login import login_required, current_user
 from openai import OpenAI
 
-from app.forms import ChatForm
-from app.models import User, PlanCadre, PlanDeCours, Cours, db, ChatHistory
+from ..forms import ChatForm
+from ..models import User, PlanCadre, PlanDeCours, Cours, db, ChatHistory
 from utils.decorator import ensure_profile_completed
 # Importez votre fonction pour récupérer la tarification depuis la BD
 from utils.openai_pricing import calculate_call_cost

--- a/src/app/routes/cours.py
+++ b/src/app/routes/cours.py
@@ -8,7 +8,7 @@ from flask_login import login_required, current_user
 from flask_wtf.csrf import validate_csrf, CSRFError
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
-from app.forms import (
+from ..forms import (
     DeleteForm,
     PlanCadreForm,
     CapaciteItemForm,
@@ -16,7 +16,7 @@ from app.forms import (
     GenerateContentForm
 )
 # Import all necessary models and the db session
-from app.models import (
+from ..models import (
     db,
     Cours,
     PlanCadre,

--- a/src/app/routes/evaluation.py
+++ b/src/app/routes/evaluation.py
@@ -25,14 +25,14 @@ from openai import OpenAIError
 from pydantic import BaseModel, Field
 from sqlalchemy import text
 
-from app.forms import (
+from ..forms import (
     CourseSelectionForm,
     PlanSelectionForm,
     EvaluationGridForm,
     EvaluationSelectionForm,
     SixLevelGridForm
 )
-from app.models import (
+from ..models import (
     db,
     Cours,
     PlanDeCours,

--- a/src/app/routes/gestion_programme.py
+++ b/src/app/routes/gestion_programme.py
@@ -10,7 +10,7 @@ from openai import OpenAI
 from pydantic import BaseModel, ValidationError
 
 # Import SQLAlchemy DB and models
-from app.models import (
+from ..models import (
     db,
     PlanDeCours,
     Cours,

--- a/src/app/routes/grilles.py
+++ b/src/app/routes/grilles.py
@@ -2,16 +2,16 @@ import os
 import uuid
 from flask import Blueprint, render_template, request, flash, redirect, url_for, current_app, Response, jsonify
 from flask_login import login_required, current_user
-from app.forms import FileUploadForm
-from app.tasks.import_grille import extract_grille_from_pdf_task
+from ..forms import FileUploadForm
+from ..tasks.import_grille import extract_grille_from_pdf_task
 import logging
 from celery.result import AsyncResult   
 from celery_app import celery
-from app.forms import (
+from ..forms import (
     ConfirmationGrilleForm
 )
 
-from app.models import db, BackupConfig, User, Competence, ElementCompetence, ElementCompetenceCriteria, \
+from ..models import db, BackupConfig, User, Competence, ElementCompetence, ElementCompetenceCriteria, \
                    ElementCompetenceParCours, FilConducteur, CoursPrealable, CoursCorequis, CompetenceParCours, \
                    PlanCadre, PlanCadreCoursCorequis, PlanCadreCapacites, PlanCadreCapaciteSavoirsNecessaires, \
                    PlanCadreCapaciteSavoirsFaire, PlanCadreCapaciteMoyensEvaluation, PlanCadreSavoirEtre, \

--- a/src/app/routes/ocr_routes.py
+++ b/src/app/routes/ocr_routes.py
@@ -9,8 +9,8 @@ from flask_login import login_required
 
 # --- Imports Projet ---
 from extensions import csrf
-from app.forms import OcrProgrammeSelectionForm
-from app.forms import AssociateDevisForm
+from ..forms import OcrProgrammeSelectionForm
+from ..forms import AssociateDevisForm
 try:
     from ocr_processing import web_utils
     from config import constants
@@ -29,7 +29,7 @@ except ImportError as e:
 
 from flask_login import login_required, current_user
 
-from app.models import (
+from ..models import (
     Programme
 )
 
@@ -165,7 +165,7 @@ def start_ocr_processing():
 
         try:
             # !!! Importation de la tâche déplacée ici !!!
-            from app.tasks.ocr import process_ocr_task
+            from ..tasks.ocr import process_ocr_task
             logger.info(f"Tentative d'envoi de la tâche 'app.tasks.process_ocr_task' via celery.send_task")
             logger.info(f"Configuration Celery utilisée: BROKER='{celery.conf.broker_url}', BACKEND='{celery.conf.result_backend}'")
 

--- a/src/app/routes/plan_cadre.py
+++ b/src/app/routes/plan_cadre.py
@@ -5,13 +5,13 @@ import traceback
 from flask import Blueprint, render_template, redirect, url_for, request, flash, send_file, jsonify, session
 from flask_login import login_required, current_user
 
-from app.forms import (
+from ..forms import (
     DeleteForm,
     PlanCadreForm,
     GenerateContentForm
 )
 # Import SQLAlchemy DB and models
-from app.models import (
+from ..models import (
     db,
     PlanCadre,
     PlanCadreCapacites,
@@ -48,7 +48,7 @@ plan_cadre_bp = Blueprint('plan_cadre', __name__, url_prefix='/plan_cadre')
 @roles_required('admin', 'coordo')
 @ensure_profile_completed
 def generate_plan_cadre_content(plan_id):
-    from app.tasks.generation_plan_cadre import generate_plan_cadre_content_task
+    from ..tasks.generation_plan_cadre import generate_plan_cadre_content_task
 
     plan = PlanCadre.query.get(plan_id)
     if not plan:

--- a/src/app/routes/plan_de_cours.py
+++ b/src/app/routes/plan_de_cours.py
@@ -16,8 +16,8 @@ from openai import OpenAIError
 from pydantic import BaseModel, Field
 from sqlalchemy import func
 
-from app.forms import PlanDeCoursForm
-from app.models import (
+from ..forms import PlanDeCoursForm
+from ..models import (
     db, Cours, PlanCadre, User,
     PlanDeCours, PlanDeCoursCalendrier, PlanDeCoursMediagraphie,
     PlanDeCoursDisponibiliteEnseignant, PlanDeCoursEvaluations, PlanDeCoursEvaluationsCapacites, Programme,

--- a/src/app/routes/programme.py
+++ b/src/app/routes/programme.py
@@ -12,13 +12,13 @@ import html
 import json
 from flask_login import login_required, current_user
 
-from app.forms import (
+from ..forms import (
     CompetenceForm,
     DeleteForm,
     ReviewImportConfirmForm
 )
 # Import SQLAlchemy models
-from app.models import (
+from ..models import (
     db,
     User,
     Programme,

--- a/src/app/routes/routes.py
+++ b/src/app/routes/routes.py
@@ -12,7 +12,7 @@ from flask_login import login_user, logout_user, login_required, current_user
 from sqlalchemy import func  # Add this at the top with your other imports
 from werkzeug.security import generate_password_hash, check_password_hash
 
-from app.forms import (
+from ..forms import (
     ProgrammeForm,
     CompetenceForm,
     ElementCompetenceForm,
@@ -39,7 +39,7 @@ from app.forms import (
     ResetPasswordForm
 
 )
-from app.models import (
+from ..models import (
     db,
     User,
     Department,

--- a/src/app/routes/settings.py
+++ b/src/app/routes/settings.py
@@ -6,9 +6,9 @@ from flask import send_from_directory, current_app
 from flask_login import login_required, current_user
 from flask_wtf.csrf import CSRFProtect
 
-from app.forms import GlobalGenerationSettingsForm, DeletePlanForm, UploadForm, ProfileEditForm, AnalysePromptForm, \
+from ..forms import GlobalGenerationSettingsForm, DeletePlanForm, UploadForm, ProfileEditForm, AnalysePromptForm, \
     OpenAIModelForm
-from app.routes.evaluation import AISixLevelGridResponse
+from .evaluation import AISixLevelGridResponse
 from config.constants import SECTIONS  # Importer la liste des sections
 from utils.decorator import role_required, roles_required, ensure_profile_completed
 
@@ -16,7 +16,7 @@ csrf = CSRFProtect()
 
 
 # Importez bien sûr db, User et GlobalGenerationSettings depuis vos modèles
-from app.models import db, User, GlobalGenerationSettings, GrillePromptSettings, PlanDeCours, Cours, Programme, PlanDeCoursPromptSettings, AnalysePlanCoursPrompt, ListeCegep, Department, OpenAIModel
+from ..models import db, User, GlobalGenerationSettings, GrillePromptSettings, PlanDeCours, Cours, Programme, PlanDeCoursPromptSettings, AnalysePlanCoursPrompt, ListeCegep, Department, OpenAIModel
 
 settings_bp = Blueprint('settings', __name__, url_prefix='/settings')
 

--- a/src/app/routes/system.py
+++ b/src/app/routes/system.py
@@ -19,8 +19,8 @@ from flask import (
 from flask_login import login_required
 from sqlalchemy import text
 
-from app.forms import BackupConfigForm, MailgunConfigForm
-from app.models import db, BackupConfig, DBChange, User, MailgunConfig
+from ..forms import BackupConfigForm, MailgunConfigForm
+from ..models import db, BackupConfig, DBChange, User, MailgunConfig
 from utils.backup_utils import send_backup_email
 from utils.decorator import roles_required, ensure_profile_completed
 from utils.scheduler_instance import scheduler, schedule_backup

--- a/src/app/tasks/generation_plan_cadre.py
+++ b/src/app/tasks/generation_plan_cadre.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy import text
 
 # Import your models – adjust these imports as needed:
-from app.models import (
+from ..models import (
     PlanCadre, GlobalGenerationSettings, Competence, ElementCompetence,
     ElementCompetenceParCours, CoursCorequis, Cours, CoursPrealable,
     PlanCadreSavoirEtre, PlanCadreCapacites,

--- a/src/app/tasks/ocr.py
+++ b/src/app/tasks/ocr.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy import text
 
 # Import your models – adjust these imports as needed:
-from app.models import (
+from ..models import (
     PlanCadre, GlobalGenerationSettings, Competence, ElementCompetence,
     ElementCompetenceParCours, CoursCorequis, Cours, CoursPrealable,
     PlanCadreSavoirEtre, PlanCadreCapacites,


### PR DESCRIPTION
## Summary
- Use relative imports throughout `src/app` modules instead of absolute `app.*`
- Update tasks and routes to reference sibling packages with appropriate relative paths

## Testing
- `pytest` *(fails: Table 'User_Programme' is already defined)*

------
https://chatgpt.com/codex/tasks/task_e_6897401222b083229b40244a69454c10