### PR TITLE
Avoid SQLAlchemy table redefinitions

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,3 +1,10 @@
+"""Application factory and setup for the EDxo project."""
+
+import sys
+
+# Ensure consistent module imports whether using ``app`` or ``src.app``
+sys.modules.setdefault("app", sys.modules[__name__])
+
 # src/app/__init__.py
 
 # TODO: Ajouter un status au plan de cours (Brouillon, en révision, complété), Permettre l'édition seulement lorsqu'en brouillon pour le prof. Permettre l'édition lorsqu'il est en révision par le coordo.

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+import sys
+
 from flask import current_app
 from flask_login import UserMixin
 from sqlalchemy import UniqueConstraint, select
@@ -7,10 +9,15 @@ from sqlalchemy.ext.hybrid import hybrid_property
 
 from extensions import db
 
+# Alias to prevent duplicate imports when modules use ``app.models``
+sys.modules.setdefault("app.models", sys.modules[__name__])
+
 # Association table for User-Programme many-to-many relationship
-user_programme = db.Table('User_Programme',
+user_programme = db.Table(
+    'User_Programme',
     db.Column('user_id', db.Integer, db.ForeignKey('User.id', ondelete='CASCADE'), primary_key=True),
-    db.Column('programme_id', db.Integer, db.ForeignKey('Programme.id', ondelete='CASCADE'), primary_key=True)
+    db.Column('programme_id', db.Integer, db.ForeignKey('Programme.id', ondelete='CASCADE'), primary_key=True),
+    extend_existing=True,
 )
 
 # Association table for Cours-Programme with per-programme session
@@ -33,7 +40,8 @@ class CoursProgramme(db.Model):
 competence_programme = db.Table(
     'Competence_Programme',
     db.Column('competence_id', db.Integer, db.ForeignKey('Competence.id', ondelete='CASCADE'), primary_key=True),
-    db.Column('programme_id',   db.Integer, db.ForeignKey('Programme.id',    ondelete='CASCADE'), primary_key=True)
+    db.Column('programme_id',   db.Integer, db.ForeignKey('Programme.id',    ondelete='CASCADE'), primary_key=True),
+    extend_existing=True,
 )
 
 

--- a/src/wsgi.py
+++ b/src/wsgi.py
@@ -1,4 +1,12 @@
-# src/wsgi.py
+"""WSGI entrypoint for running the EDxo app with Gunicorn."""
+
+import os
+import sys
+
+# Ensure the ``src`` directory is on ``sys.path`` so absolute imports like
+# ``extensions`` resolve when the app is loaded via ``src.wsgi``.
+sys.path.insert(0, os.path.dirname(__file__))
+
 from .app import create_app  # <- import relatif
 
 # Create the Flask application instance


### PR DESCRIPTION
## Summary
- prevent duplicate module imports by aliasing `app` package
- allow reusing existing association tables to avoid metadata conflicts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689778c8548c8322a96b99b78c18e3a0