### PR TITLE
Permettre la configuration des modèles du chat

### DIFF
--- a/src/app/forms.py
+++ b/src/app/forms.py
@@ -130,6 +130,37 @@ class OpenAIModelForm(FlaskForm):
     output_price = DecimalField("Prix en output (par token)", validators=[DataRequired(), NumberRange(min=0)])
     submit = SubmitField("Ajouter")
 
+
+class ChatSettingsForm(FlaskForm):
+    chat_model = SelectField('Modèle pour le chat', validators=[DataRequired()])
+    tool_model = SelectField("Modèle pour l'appel d'outils", validators=[DataRequired()])
+    reasoning_effort = SelectField(
+        "Effort de raisonnement",
+        choices=[
+            ('minimal', 'Minimal'),
+            ('low', 'Faible'),
+            ('medium', 'Moyen'),
+            ('high', 'Élevé')
+        ],
+        default='medium'
+    )
+    verbosity = SelectField(
+        "Verbosité",
+        choices=[
+            ('low', 'Faible'),
+            ('medium', 'Moyenne'),
+            ('high', 'Élevée')
+        ],
+        default='medium'
+    )
+    submit = SubmitField('Enregistrer')
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        models = get_all_models()
+        self.chat_model.choices = [(model.name, model.name) for model in models]
+        self.tool_model.choices = [(model.name, model.name) for model in models]
+
 class MultiCheckboxField(SelectMultipleField):
     widget = widgets.ListWidget(prefix_label=False)
     option_widget = widgets.CheckboxInput()

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -64,6 +64,26 @@ class OpenAIModel(db.Model):
     def __repr__(self):
         return f"<OpenAIModel {self.name}>"
 
+
+class ChatModelConfig(db.Model):
+    __tablename__ = 'chat_model_config'
+
+    id = db.Column(db.Integer, primary_key=True)
+    chat_model = db.Column(db.String(64), nullable=False, default='gpt-4.1-mini')
+    tool_model = db.Column(db.String(64), nullable=False, default='gpt-4.1-mini')
+    reasoning_effort = db.Column(db.String(16))
+    verbosity = db.Column(db.String(16))
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    @classmethod
+    def get_current(cls):
+        config = cls.query.first()
+        if not config:
+            config = cls()
+            db.session.add(config)
+            db.session.commit()
+        return config
+
 class AnalysePlanCoursPrompt(db.Model):
     __tablename__ = 'analyse_plan_cours_prompt'
     

--- a/src/app/templates/parametres.html
+++ b/src/app/templates/parametres.html
@@ -62,6 +62,9 @@
                       <a href="{{ url_for('settings.configure_analyse_prompt') }}" class="list-group-item list-group-item-action {% if request.endpoint == 'settings.configure_analyse_prompt' %}active{% endif %}">
                         <i class="bi bi-chat-text me-2"></i>Analyse des plans de cours
                       </a>
+                      <a href="{{ url_for('settings.chat_model_settings') }}" class="list-group-item list-group-item-action {% if request.endpoint == 'settings.chat_model_settings' %}active{% endif %}">
+                        <i class="bi bi-chat-dots me-2"></i>Chat IA
+                      </a>
                       <a href="{{ url_for('settings.manage_openai_models') }}" class="list-group-item list-group-item-action {% if request.endpoint == 'settings.manage_openai_models' %}active{% endif %}">
                         <i class="bi bi-cpu me-2"></i>Modèles OpenAI
                       </a>

--- a/src/app/templates/settings/chat_models.html
+++ b/src/app/templates/settings/chat_models.html
@@ -1,0 +1,26 @@
+{% extends "parametres.html" %}
+{% block parametres_content %}
+  <h1>Paramètres du chat IA</h1>
+  <form method="post">
+    {{ form.hidden_tag() }}
+    <div>
+      {{ form.chat_model.label }}<br>
+      {{ form.chat_model(class="form-select") }}
+    </div>
+    <div class="mt-3">
+      {{ form.tool_model.label }}<br>
+      {{ form.tool_model(class="form-select") }}
+    </div>
+    <div class="mt-3">
+      {{ form.reasoning_effort.label }}<br>
+      {{ form.reasoning_effort(class="form-select") }}
+    </div>
+    <div class="mt-3">
+      {{ form.verbosity.label }}<br>
+      {{ form.verbosity(class="form-select") }}
+    </div>
+    <div class="mt-3">
+      {{ form.submit(class="btn btn-primary") }}
+    </div>
+  </form>
+{% endblock %}

--- a/src/migrations/versions/0d1e92a8b7cd_add_chat_model_config.py
+++ b/src/migrations/versions/0d1e92a8b7cd_add_chat_model_config.py
@@ -1,0 +1,31 @@
+"""add chat model config
+
+Revision ID: 0d1e92a8b7cd
+Revises: 19b209438a4e
+Create Date: 2025-05-06 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0d1e92a8b7cd'
+down_revision = '19b209438a4e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'chat_model_config',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('chat_model', sa.String(length=64), nullable=False, server_default='gpt-4.1-mini'),
+        sa.Column('tool_model', sa.String(length=64), nullable=False, server_default='gpt-4.1-mini'),
+        sa.Column('reasoning_effort', sa.String(length=16), nullable=True),
+        sa.Column('verbosity', sa.String(length=16), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table('chat_model_config')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -140,3 +140,13 @@ def test_login_with_admin(client, app, monkeypatch):
         assert "_user_id" in session, "User not logged in; session missing '_user_id'."
         # L'ID est stocké en tant que chaîne. Vérifiez qu'il correspond à celui de l'admin.
         assert session["_user_id"] == str(admin_id), "Logged in user id does not match admin's id."
+
+
+def test_chat_model_config_defaults(app):
+    with app.app_context():
+        from src.app import db
+        ChatModelConfig = get_model_by_name("ChatModelConfig", db)
+        assert ChatModelConfig is not None, "ChatModelConfig model not found."
+        cfg = ChatModelConfig.get_current()
+        assert cfg.chat_model is not None
+        assert cfg.tool_model is not None


### PR DESCRIPTION
## Summary
- Ajout d'un modèle `ChatModelConfig` pour stocker les modèles IA, l'effort de raisonnement et la verbosité
- Interface d'administration pour choisir le modèle du chat, le modèle d'outils et les paramètres de génération
- Utilisation des paramètres configurés dans la route de chat et mise à jour de la navigation des paramètres

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897ed6788648322b5462e17d145b957