### PR TITLE
Barre d'actions fixe pour le plan-cadre

### DIFF
--- a/src/app/templates/view_plan_cadre.html
+++ b/src/app/templates/view_plan_cadre.html
@@ -852,22 +852,26 @@
     <!-- Barre d'actions fixe en bas -->
     <div id="actionBar" class="fixed-bottom bg-white border-top d-none shadow">
         <div class="container py-2">
-            <div class="d-flex gap-2">
-                <button type="button"
-                        id="floatingSaveBtn"
-                        class="btn btn-primary flex-fill"
-                        name="submit_plan"
-                        value="submit_plan">
-                    <span class="btn-text">Enregistrer</span>
-                    <span class="spinner-border spinner-border-sm ms-2 d-none" role="status" id="loadingSpinner">
-                        <span class="visually-hidden">Chargement...</span>
-                    </span>
-                </button>
-                <button type="button"
-                        id="floatingCancelBtn"
-                        class="btn btn-danger flex-fill">
-                    Annuler
-                </button>
+            <div class="row g-2">
+                <div class="col">
+                    <button type="button"
+                            id="floatingSaveBtn"
+                            class="btn btn-primary w-100"
+                            name="submit_plan"
+                            value="submit_plan">
+                        <span class="btn-text">Enregistrer</span>
+                        <span class="spinner-border spinner-border-sm ms-2 d-none" role="status" id="loadingSpinner">
+                            <span class="visually-hidden">Chargement...</span>
+                        </span>
+                    </button>
+                </div>
+                <div class="col">
+                    <button type="button"
+                            id="floatingCancelBtn"
+                            class="btn btn-danger w-100">
+                        Annuler
+                    </button>
+                </div>
             </div>
         </div>
     </div>

--- a/src/app/templates/view_plan_cadre.html
+++ b/src/app/templates/view_plan_cadre.html
@@ -849,24 +849,26 @@
         </div>
     </div>
 
-    <!-- Bouton d'Enregistrement Flottant -->
-    {# Utilisation d'un bouton type="button" pour éviter une double soumission #}
-    <button type="button" 
-            id="floatingSaveBtn" 
-            class="btn btn-primary btn-lg rounded-circle shadow-lg d-none"
-            title="Enregistrer le Plan-cadre"
-            name="submit_plan"
-            value="submit_plan">
-        <i class="bi bi-save"></i>
-    </button>
-
-    <!-- Bouton Flottant "Annuler" -->
-    <button type="button" 
-            id="floatingCancelBtn" 
-            class="btn btn-danger btn-lg rounded-circle shadow-lg d-none"
-            title="Annuler les modifications">
-        <i class="bi bi-x-circle"></i>
-    </button>
+    <!-- Barre d'actions fixe en bas -->
+    <div id="actionBar" class="fixed-bottom bg-white border-top d-none shadow">
+        <div class="container py-2 d-flex justify-content-end gap-2">
+            <button type="button"
+                    id="floatingSaveBtn"
+                    class="btn btn-primary"
+                    name="submit_plan"
+                    value="submit_plan">
+                <span class="btn-text">Enregistrer</span>
+                <span class="spinner-border spinner-border-sm ms-2 d-none" role="status" id="loadingSpinner">
+                    <span class="visually-hidden">Chargement...</span>
+                </span>
+            </button>
+            <button type="button"
+                    id="floatingCancelBtn"
+                    class="btn btn-danger">
+                Annuler
+            </button>
+        </div>
+    </div>
 
     <!-- Modal Génération du Plan-cadre (Formulaire Séparé) -->
     <div class="modal fade" id="generateModal" tabindex="-1" aria-labelledby="generateModalLabel" aria-hidden="true">

--- a/src/app/templates/view_plan_cadre.html
+++ b/src/app/templates/view_plan_cadre.html
@@ -851,22 +851,24 @@
 
     <!-- Barre d'actions fixe en bas -->
     <div id="actionBar" class="fixed-bottom bg-white border-top d-none shadow">
-        <div class="container py-2 d-flex justify-content-end gap-2">
-            <button type="button"
-                    id="floatingSaveBtn"
-                    class="btn btn-primary"
-                    name="submit_plan"
-                    value="submit_plan">
-                <span class="btn-text">Enregistrer</span>
-                <span class="spinner-border spinner-border-sm ms-2 d-none" role="status" id="loadingSpinner">
-                    <span class="visually-hidden">Chargement...</span>
-                </span>
-            </button>
-            <button type="button"
-                    id="floatingCancelBtn"
-                    class="btn btn-danger">
-                Annuler
-            </button>
+        <div class="container py-2">
+            <div class="d-flex gap-2">
+                <button type="button"
+                        id="floatingSaveBtn"
+                        class="btn btn-primary flex-fill"
+                        name="submit_plan"
+                        value="submit_plan">
+                    <span class="btn-text">Enregistrer</span>
+                    <span class="spinner-border spinner-border-sm ms-2 d-none" role="status" id="loadingSpinner">
+                        <span class="visually-hidden">Chargement...</span>
+                    </span>
+                </button>
+                <button type="button"
+                        id="floatingCancelBtn"
+                        class="btn btn-danger flex-fill">
+                    Annuler
+                </button>
+            </div>
         </div>
     </div>
 

--- a/src/static/css/view_plan_cadre.css
+++ b/src/static/css/view_plan_cadre.css
@@ -28,35 +28,11 @@ h6 {
     padding: 0.2rem;
     border-bottom: 1px solid black;
 }
-#floatingSaveBtn, #floatingCancelBtn {
-    position: fixed;
-    bottom: 20px;
+
+#actionBar {
     z-index: 1000;
-    width: 60px;
-    height: 60px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 50%;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
-#floatingSaveBtn {
-    right: 20px;
-    background-color: #0d6efd;
-    color: white;
-}
-#floatingCancelBtn {
-    right: 90px;
-    background-color: #dc3545;
-    color: white;
-}
-#floatingSaveBtn .bi, #floatingCancelBtn .bi {
-    font-size: 1.5rem;
-}
-#floatingSaveBtn, #floatingCancelBtn {
-    transition: opacity 0.3s ease, visibility 0.3s ease;
-}
-#floatingSaveBtn.d-none, #floatingCancelBtn.d-none {
-    opacity: 0;
-    visibility: hidden;
+
+body.with-action-bar {
+    padding-bottom: 80px;
 }

--- a/src/static/css/view_plan_cadre.css
+++ b/src/static/css/view_plan_cadre.css
@@ -31,8 +31,9 @@ h6 {
 
 #actionBar {
     z-index: 1000;
+    padding-bottom: env(safe-area-inset-bottom);
 }
 
 body.with-action-bar {
-    padding-bottom: 80px;
+    padding-bottom: calc(80px + env(safe-area-inset-bottom));
 }

--- a/src/static/js/view_plan_cadre.js
+++ b/src/static/js/view_plan_cadre.js
@@ -377,20 +377,18 @@ function removeCapacite(button) {
 }
 
 function showFloatingButtons() {
-    const floatingSaveBtn = document.getElementById('floatingSaveBtn');
-    const floatingCancelBtn = document.getElementById('floatingCancelBtn');
-    if (floatingSaveBtn && floatingCancelBtn) {
-        floatingSaveBtn.classList.remove('d-none');
-        floatingCancelBtn.classList.remove('d-none');
+    const actionBar = document.getElementById('actionBar');
+    if (actionBar) {
+        actionBar.classList.remove('d-none');
+        document.body.classList.add('with-action-bar');
     }
 }
 
 function hideFloatingButtons() {
-    const floatingSaveBtn = document.getElementById('floatingSaveBtn');
-    const floatingCancelBtn = document.getElementById('floatingCancelBtn');
-    if (floatingSaveBtn && floatingCancelBtn) {
-        floatingSaveBtn.classList.add('d-none');
-        floatingCancelBtn.classList.add('d-none');
+    const actionBar = document.getElementById('actionBar');
+    if (actionBar) {
+        actionBar.classList.add('d-none');
+        document.body.classList.remove('with-action-bar');
     }
 }
 


### PR DESCRIPTION
## Summary
- remplace les boutons flottants par une barre d'actions en bas avec "Enregistrer" et "Annuler"
- ajuste le CSS pour la barre fixe et l'espacement du formulaire
- met à jour la logique JS pour afficher/masquer la barre et gérer la soumission

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68980392d0a8832299a883daa4636538