### PR TITLE
Ajoute menu Scrollspy pour naviguer dans le plan-cadre

### DIFF
--- a/src/app/templates/view_plan_cadre.html
+++ b/src/app/templates/view_plan_cadre.html
@@ -4,10 +4,41 @@
     {{ super() }}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/view_plan_cadre.css') }}">
     <script src="{{ url_for('static', filename='js/view_plan_cadre.js') }}" defer></script>
+    <style>
+        html { scroll-behavior: smooth; }
+    </style>
 {% endblock %}
 
 {% block content %}
 <div class="container mt-5">
+    <button class="btn btn-outline-primary d-md-none mb-3" type="button"
+            data-bs-toggle="offcanvas" data-bs-target="#sectionsOffcanvas" aria-controls="sectionsOffcanvas">
+        Sections
+    </button>
+    <nav id="sectionsNav" class="nav nav-pills flex-column d-none d-md-block position-fixed top-50 start-0 translate-middle-y ms-3">
+        <a class="nav-link" href="#partie-1">Partie 1</a>
+        <a class="nav-link" href="#partie-2">Partie 2</a>
+        <a class="nav-link" href="#partie-3">Partie 3</a>
+        <a class="nav-link" href="#partie-4">Partie 4</a>
+        <a class="nav-link" href="#partie-5">Partie 5</a>
+        <a class="nav-link" href="#partie-6">Partie 6</a>
+    </nav>
+    <div class="offcanvas offcanvas-start" tabindex="-1" id="sectionsOffcanvas" aria-labelledby="sectionsOffcanvasLabel">
+        <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="sectionsOffcanvasLabel">Sections</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Fermer"></button>
+        </div>
+        <div class="offcanvas-body">
+            <nav class="nav flex-column">
+                <a class="nav-link" href="#partie-1" data-bs-dismiss="offcanvas">Partie 1</a>
+                <a class="nav-link" href="#partie-2" data-bs-dismiss="offcanvas">Partie 2</a>
+                <a class="nav-link" href="#partie-3" data-bs-dismiss="offcanvas">Partie 3</a>
+                <a class="nav-link" href="#partie-4" data-bs-dismiss="offcanvas">Partie 4</a>
+                <a class="nav-link" href="#partie-5" data-bs-dismiss="offcanvas">Partie 5</a>
+                <a class="nav-link" href="#partie-6" data-bs-dismiss="offcanvas">Partie 6</a>
+            </nav>
+        </div>
+    </div>
     <!-- Titre du Cours -->
     <div class="mb-3 text-center">
         <h1>Plan-cadre pour le cours : {{ cours.code }} - {{ cours.nom }}</h1>
@@ -46,7 +77,7 @@
 
         <div class="accordion" id="planCadreAccordion">
             <!-- PARTIE 1: Identification du cours -->
-            <div class="accordion-item">
+            <div class="accordion-item" id="partie-1">
                 <h2 class="accordion-header" id="headingGeneralInfo">
                     <button class="accordion-button bg-light" type="button"
                             data-bs-toggle="collapse"
@@ -104,7 +135,7 @@
             </div>
 
             <!-- PARTIE 2: Repères généraux au sujet du cours -->
-            <div class="accordion-item">
+            <div class="accordion-item" id="partie-2">
                 <h2 class="accordion-header" id="headingIntroduction">
                     <button class="accordion-button bg-primary text-white" type="button"
                             data-bs-toggle="collapse"
@@ -402,7 +433,7 @@
             </div>
 
             <!-- PARTIE 3: Résultats visés -->
-            <div class="accordion-item">
+            <div class="accordion-item" id="partie-3">
                 <h2 class="accordion-header" id="headingResultatsVises">
                     <button class="accordion-button bg-info text-white" type="button"
                             data-bs-toggle="collapse"
@@ -604,7 +635,7 @@
             </div>
 
             <!-- PARTIE 4: Organisation de l'apprentissage et de l'enseignement -->
-            <div class="accordion-item">
+            <div class="accordion-item" id="partie-4">
                 <h2 class="accordion-header" id="headingOrganisation">
                     <button class="accordion-button bg-secondary text-white" type="button"
                             data-bs-toggle="collapse"
@@ -675,7 +706,7 @@
             </div>
 
             <!-- PARTIE 5: Évaluation des apprentissages -->
-            <div class="accordion-item">
+            <div class="accordion-item" id="partie-5">
                 <h2 class="accordion-header" id="headingEvaluation">
                     <button class="accordion-button bg-warning text-dark" type="button"
                             data-bs-toggle="collapse"
@@ -787,7 +818,7 @@
 
 
             <!-- PARTIE 6: Éléments de compétence associés -->
-            <div class="accordion-item">
+            <div class="accordion-item" id="partie-6">
                 <h2 class="accordion-header" id="headingElementsCompetence">
                     <button class="accordion-button bg-primary text-white" type="button"
                             data-bs-toggle="collapse"

--- a/src/app/templates/view_plan_cadre.html
+++ b/src/app/templates/view_plan_cadre.html
@@ -16,12 +16,12 @@
         Sections
     </button>
     <nav id="sectionsNav" class="nav nav-pills flex-column d-none d-md-block position-fixed top-50 start-0 translate-middle-y ms-3">
-        <a class="nav-link" href="#partie-1">Partie 1</a>
-        <a class="nav-link" href="#partie-2">Partie 2</a>
-        <a class="nav-link" href="#partie-3">Partie 3</a>
-        <a class="nav-link" href="#partie-4">Partie 4</a>
-        <a class="nav-link" href="#partie-5">Partie 5</a>
-        <a class="nav-link" href="#partie-6">Partie 6</a>
+        <a class="nav-link" href="#partie-1">Partie 1&nbsp;-&nbsp;Identification du cours</a>
+        <a class="nav-link" href="#partie-2">Partie 2&nbsp;-&nbsp;Repères généraux</a>
+        <a class="nav-link" href="#partie-3">Partie 3&nbsp;-&nbsp;Résultats visés</a>
+        <a class="nav-link" href="#partie-4">Partie 4&nbsp;-&nbsp;Organisation de l'apprentissage</a>
+        <a class="nav-link" href="#partie-5">Partie 5&nbsp;-&nbsp;Évaluation des apprentissages</a>
+        <a class="nav-link" href="#partie-6">Partie 6&nbsp;-&nbsp;Éléments de compétence</a>
     </nav>
     <div class="offcanvas offcanvas-start" tabindex="-1" id="sectionsOffcanvas" aria-labelledby="sectionsOffcanvasLabel">
         <div class="offcanvas-header">
@@ -30,12 +30,12 @@
         </div>
         <div class="offcanvas-body">
             <nav class="nav flex-column">
-                <a class="nav-link" href="#partie-1" data-bs-dismiss="offcanvas">Partie 1</a>
-                <a class="nav-link" href="#partie-2" data-bs-dismiss="offcanvas">Partie 2</a>
-                <a class="nav-link" href="#partie-3" data-bs-dismiss="offcanvas">Partie 3</a>
-                <a class="nav-link" href="#partie-4" data-bs-dismiss="offcanvas">Partie 4</a>
-                <a class="nav-link" href="#partie-5" data-bs-dismiss="offcanvas">Partie 5</a>
-                <a class="nav-link" href="#partie-6" data-bs-dismiss="offcanvas">Partie 6</a>
+                <a class="nav-link" href="#partie-1">Partie 1&nbsp;-&nbsp;Identification du cours</a>
+                <a class="nav-link" href="#partie-2">Partie 2&nbsp;-&nbsp;Repères généraux</a>
+                <a class="nav-link" href="#partie-3">Partie 3&nbsp;-&nbsp;Résultats visés</a>
+                <a class="nav-link" href="#partie-4">Partie 4&nbsp;-&nbsp;Organisation de l'apprentissage</a>
+                <a class="nav-link" href="#partie-5">Partie 5&nbsp;-&nbsp;Évaluation des apprentissages</a>
+                <a class="nav-link" href="#partie-6">Partie 6&nbsp;-&nbsp;Éléments de compétence</a>
             </nav>
         </div>
     </div>

--- a/src/static/js/view_plan_cadre.js
+++ b/src/static/js/view_plan_cadre.js
@@ -693,25 +693,41 @@ document.addEventListener('DOMContentLoaded', function() {
         scrollSpyInstance = new bootstrap.ScrollSpy(document.body, { target: '#sectionsNav', offset: 100 });
     }
     document.querySelectorAll('#sectionsNav .nav-link, #sectionsOffcanvas .nav-link').forEach(link => {
-        link.addEventListener('click', () => {
+        link.addEventListener('click', (e) => {
+            e.preventDefault();
             const targetSelector = link.getAttribute('href');
-            if (targetSelector && targetSelector.startsWith('#')) {
-                const item = document.querySelector(targetSelector);
-                if (item) {
-                    const collapseEl = item.querySelector('.accordion-collapse');
-                    if (collapseEl) {
-                        const collapseInstance = bootstrap.Collapse.getOrCreateInstance(collapseEl, { toggle: false });
-                        collapseInstance.show();
-                        if (scrollSpyInstance) {
-                            scrollSpyInstance.refresh();
-                        }
-                    }
-                }
+            if (!targetSelector || !targetSelector.startsWith('#')) {
+                return;
             }
+            const item = document.querySelector(targetSelector);
+            if (!item) {
+                return;
+            }
+
+            const collapseEl = item.querySelector('.accordion-collapse');
+            if (collapseEl) {
+                const collapseInstance = bootstrap.Collapse.getOrCreateInstance(collapseEl, { toggle: false });
+                collapseInstance.show();
+            }
+
+            const scrollToTarget = () => {
+                item.scrollIntoView({ behavior: 'smooth' });
+                if (scrollSpyInstance) {
+                    scrollSpyInstance.refresh();
+                }
+            };
+
             const offcanvasEl = document.getElementById('sectionsOffcanvas');
             const offcanvas = bootstrap.Offcanvas.getInstance(offcanvasEl);
             if (offcanvas) {
+                const handler = () => {
+                    offcanvasEl.removeEventListener('hidden.bs.offcanvas', handler);
+                    scrollToTarget();
+                };
+                offcanvasEl.addEventListener('hidden.bs.offcanvas', handler);
                 offcanvas.hide();
+            } else {
+                scrollToTarget();
             }
         });
     });

--- a/src/static/js/view_plan_cadre.js
+++ b/src/static/js/view_plan_cadre.js
@@ -686,4 +686,18 @@ document.addEventListener('DOMContentLoaded', function() {
             console.error("Erreur lors de la génération du plan-cadre:", error);
         });
     });
+
+    const sectionsNav = document.getElementById('sectionsNav');
+    if (sectionsNav) {
+        new bootstrap.ScrollSpy(document.body, { target: '#sectionsNav', offset: 100 });
+    }
+    document.querySelectorAll('#sectionsOffcanvas .nav-link').forEach(link => {
+        link.addEventListener('click', () => {
+            const offcanvasEl = document.getElementById('sectionsOffcanvas');
+            const offcanvas = bootstrap.Offcanvas.getInstance(offcanvasEl);
+            if (offcanvas) {
+                offcanvas.hide();
+            }
+        });
+    });
 });

--- a/src/static/js/view_plan_cadre.js
+++ b/src/static/js/view_plan_cadre.js
@@ -688,8 +688,9 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     const sectionsNav = document.getElementById('sectionsNav');
+    let scrollSpyInstance;
     if (sectionsNav) {
-        new bootstrap.ScrollSpy(document.body, { target: '#sectionsNav', offset: 100 });
+        scrollSpyInstance = new bootstrap.ScrollSpy(document.body, { target: '#sectionsNav', offset: 100 });
     }
     document.querySelectorAll('#sectionsNav .nav-link, #sectionsOffcanvas .nav-link').forEach(link => {
         link.addEventListener('click', () => {
@@ -699,7 +700,11 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (item) {
                     const collapseEl = item.querySelector('.accordion-collapse');
                     if (collapseEl) {
-                        new bootstrap.Collapse(collapseEl, { toggle: true });
+                        const collapseInstance = bootstrap.Collapse.getOrCreateInstance(collapseEl, { toggle: false });
+                        collapseInstance.show();
+                        if (scrollSpyInstance) {
+                            scrollSpyInstance.refresh();
+                        }
                     }
                 }
             }

--- a/src/static/js/view_plan_cadre.js
+++ b/src/static/js/view_plan_cadre.js
@@ -691,8 +691,18 @@ document.addEventListener('DOMContentLoaded', function() {
     if (sectionsNav) {
         new bootstrap.ScrollSpy(document.body, { target: '#sectionsNav', offset: 100 });
     }
-    document.querySelectorAll('#sectionsOffcanvas .nav-link').forEach(link => {
+    document.querySelectorAll('#sectionsNav .nav-link, #sectionsOffcanvas .nav-link').forEach(link => {
         link.addEventListener('click', () => {
+            const targetSelector = link.getAttribute('href');
+            if (targetSelector && targetSelector.startsWith('#')) {
+                const item = document.querySelector(targetSelector);
+                if (item) {
+                    const collapseEl = item.querySelector('.accordion-collapse');
+                    if (collapseEl) {
+                        new bootstrap.Collapse(collapseEl, { toggle: true });
+                    }
+                }
+            }
             const offcanvasEl = document.getElementById('sectionsOffcanvas');
             const offcanvas = bootstrap.Offcanvas.getInstance(offcanvasEl);
             if (offcanvas) {


### PR DESCRIPTION
## Summary
- Ajoute une barre latérale Scrollspy listant chaque partie du plan-cadre et offcanvas mobile
- Ajoute des identifiants d’ancrage `partie-1` à `partie-6`
- Initialise le Scrollspy et fermeture de l’offcanvas côté client

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68980a243fb48322974207ab3bbd123b