### PR TITLE
Empile boutons plan-cadre sur petits écrans

### DIFF
--- a/src/app/templates/view_plan_cadre.html
+++ b/src/app/templates/view_plan_cadre.html
@@ -14,7 +14,7 @@
     </div>
 
     <!-- Boutons d'Action Supplémentaires -->
-    <div class="d-flex gap-3 mb-5 align-items-center">
+    <div class="d-flex flex-column flex-sm-row gap-3 mb-5 align-items-center">
         {% if current_user.role in ['admin', 'coordo'] %}
         <button type="button" id="openGenerateBtn" class="btn btn-success d-flex align-items-center" data-bs-toggle="modal" data-bs-target="#generateModal">
             <i class="bi bi-box-arrow-up-right me-2"></i>


### PR DESCRIPTION
## Summary
- Aligne verticalement les boutons d'action du plan-cadre sur les écrans XS et horizontalement à partir de SM avec `flex-column flex-sm-row`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68980fe558dc8322bc852544479e68cf