### PR TITLE
Adapte le modal du plan de cours aux écrans mobiles

### DIFF
--- a/src/app/templates/view_programme.html
+++ b/src/app/templates/view_programme.html
@@ -223,7 +223,7 @@
 
 <!-- Modal Gestion du Plan de Cours -->
 <div class="modal fade" id="planCoursModal" tabindex="-1" aria-labelledby="planCoursModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-lg">
+  <div class="modal-dialog modal-fullscreen-sm-down">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="planCoursModalLabel">Gestion du plan de cours</h5>


### PR DESCRIPTION
## Summary
- utilise `modal-fullscreen-sm-down` pour que le modal occupe toute la largeur sur petits écrans

## Testing
- `pytest -q`
- visualisation mobile: le modal n'excède plus la largeur de l'écran

------
https://chatgpt.com/codex/tasks/task_e_689812d869048322911a3bd601273772