### PR TITLE
Externalise les modèles IA par défaut

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ Production : Lit les paramètres depuis les variables d'environnement et configu
 Test : Utilise une base de données SQLite en mémoire et désactive la protection CSRF.
 La configuration est gérée dans la fonction create_app située dans src/app/__init__.py.
 
+### 4.3 Changer les modèles IA par défaut
+
+Les champs `chat_model`, `tool_model` et `ai_model` des tables associées ne possèdent plus de valeur par défaut codée en dur. Lors de la première initialisation, les valeurs sont lues depuis la configuration de l'application :
+
+- `DEFAULT_CHAT_MODEL`
+- `DEFAULT_TOOL_MODEL`
+- `DEFAULT_ANALYSE_AI_MODEL`
+
+Ces variables peuvent être définies dans le fichier `.env` avant la création de la base de données. Une fois l'application démarrée, les modèles peuvent être ajustés sans modifier le code :
+
+1. **Via l'interface d'administration** :
+   - `/settings/chat_models` pour les modèles de conversation.
+   - `/settings/analyse_prompt` pour le modèle d'analyse de plan de cours.
+2. **Directement en base** : mettre à jour les tables `chat_model_config` ou `analyse_plan_cours_prompt` via un outil SQL.
+
+Ainsi, il suffit de modifier la base ou d'utiliser la page d'admin pour changer ces valeurs.
+
 ## 5. Exécution de l'application
 ### 5.1 Mode Développement
 

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -83,6 +83,9 @@ class TestConfig:
     SECRET_KEY = 'test_key'
     RECAPTCHA_PUBLIC_KEY = 'test_public'
     RECAPTCHA_SECRET_KEY = 'test_secret'
+    DEFAULT_CHAT_MODEL = 'gpt-4.1-mini'
+    DEFAULT_TOOL_MODEL = 'gpt-4.1-mini'
+    DEFAULT_ANALYSE_AI_MODEL = 'gpt-4o'
     # Add other testing-specific configurations here
 
 
@@ -128,6 +131,9 @@ def create_app(testing=False):
             MISTRAL_MODEL_OCR="mistral-ocr-latest",
             OPENAI_MODEL_SECTION = "gpt-4.1", # Modèle pour la détection de section
             OPENAI_MODEL_EXTRACTION = "gpt-4.1-mini", # Modèle pour l'extraction de compétences
+            DEFAULT_CHAT_MODEL=os.getenv('DEFAULT_CHAT_MODEL', 'gpt-4.1-mini'),
+            DEFAULT_TOOL_MODEL=os.getenv('DEFAULT_TOOL_MODEL', os.getenv('DEFAULT_CHAT_MODEL', 'gpt-4.1-mini')),
+            DEFAULT_ANALYSE_AI_MODEL=os.getenv('DEFAULT_ANALYSE_AI_MODEL', 'gpt-4o'),
             WTF_CSRF_ENABLED=True,
             CKEDITOR_PKG_TYPE='standard',
             PERMANENT_SESSION_LIFETIME=timedelta(days=30),


### PR DESCRIPTION
## Summary
- utilise la configuration pour initialiser `ChatModelConfig` et `AnalysePlanCoursPrompt`
- lit les valeurs par défaut des modèles IA depuis l'environnement
- documente la mise à jour des modèles sans modifier le code

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68981f915cb083229ef87e24d33d685b