### PR TITLE
Ajoute configuration modèle IA

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -128,6 +128,7 @@ def create_app(testing=False):
             MISTRAL_MODEL_OCR="mistral-ocr-latest",
             OPENAI_MODEL_SECTION = "gpt-4.1", # Modèle pour la détection de section
             OPENAI_MODEL_EXTRACTION = "gpt-4.1-mini", # Modèle pour l'extraction de compétences
+            DEFAULT_CHAT_MODEL=os.getenv('DEFAULT_CHAT_MODEL'),
             WTF_CSRF_ENABLED=True,
             CKEDITOR_PKG_TYPE='standard',
             PERMANENT_SESSION_LIFETIME=timedelta(days=30),
@@ -143,6 +144,7 @@ def create_app(testing=False):
         )
         Session(app)
 
+    app.config.setdefault('DEFAULT_CHAT_MODEL', os.getenv('DEFAULT_CHAT_MODEL'))
     # Jinja filter to compute perceived brightness of a hex color
     def brightness(hex_color):
         if not hex_color:

--- a/src/app/routes/chat.py
+++ b/src/app/routes/chat.py
@@ -1,6 +1,6 @@
 # chat.py – Responses API + DEBUG (SDK 1.23 → ≥1.25) - WITH ADDED LOGGING
 import json, pprint, tiktoken, logging
-from flask import Blueprint, render_template, request, Response, stream_with_context, session
+from flask import Blueprint, render_template, request, Response, stream_with_context, session, current_app
 from flask_login import login_required, current_user
 from openai import OpenAI, OpenAIError
 import itertools
@@ -430,7 +430,9 @@ def send_message():
 
     client = OpenAI(api_key=current_user.openai_key)
     cfg = ChatModelConfig.get_current()
-    chat_model = cfg.chat_model or "gpt-4.1-mini"
+    override = data.get("model") or request.args.get("model") or request.form.get("model")
+    default_model = current_app.config.get("DEFAULT_CHAT_MODEL") or cfg.chat_model
+    chat_model = override or default_model
     tool_model = cfg.tool_model or chat_model
     reasoning_effort = cfg.reasoning_effort
     verbosity = cfg.verbosity

--- a/src/app/routes/evaluation.py
+++ b/src/app/routes/evaluation.py
@@ -43,7 +43,8 @@ from ..models import (
     EvaluationSavoirFaire,
     PlanCadreCapaciteSavoirsFaire,
     GrillePromptSettings,
-    User
+    User,
+    ChatModelConfig,
 )
 from utils.decorator import roles_required, ensure_profile_completed
 from utils.openai_pricing import calculate_call_cost
@@ -460,7 +461,13 @@ def generate_six_level_grid():
     if not user or not user.openai_key:
         return jsonify({'error': 'Clé OpenAI non configurée'}), 400
 
-    ai_model = "gpt-4o"
+    cfg = ChatModelConfig.get_current()
+    override = (
+        data.get('model')
+        or request.args.get('model')
+        or request.form.get('model')
+    )
+    ai_model = override or current_app.config.get('DEFAULT_CHAT_MODEL') or cfg.chat_model
 
     user_credits = user.credits
     user_id = current_user.id

--- a/src/app/routes/plan_de_cours.py
+++ b/src/app/routes/plan_de_cours.py
@@ -21,7 +21,7 @@ from ..models import (
     db, Cours, PlanCadre, User,
     PlanDeCours, PlanDeCoursCalendrier, PlanDeCoursMediagraphie,
     PlanDeCoursDisponibiliteEnseignant, PlanDeCoursEvaluations, PlanDeCoursEvaluationsCapacites, Programme,
-    PlanDeCoursPromptSettings
+    PlanDeCoursPromptSettings, ChatModelConfig
 )
 from utils.decorator import ensure_profile_completed
 from utils.openai_pricing import calculate_call_cost
@@ -186,7 +186,13 @@ def generate_content():
         print(f"Clé manquante dans le contexte : {e}")
         return jsonify({'error': f'Variable manquante dans le contexte: {str(e)}'}), 400
 
-    ai_model = "gpt-4o"
+    cfg = ChatModelConfig.get_current()
+    override = (
+        data.get('model')
+        or request.args.get('model')
+        or request.form.get('model')
+    )
+    ai_model = override or current_app.config.get('DEFAULT_CHAT_MODEL') or cfg.chat_model
 
 
     user = db.session.query(User).with_for_update().get(current_user.id)


### PR DESCRIPTION
## Résumé
- ajoute la clé `DEFAULT_CHAT_MODEL` dans la configuration Flask
- permet de surcharger le modèle dans les routes chat, plan de cours et évaluation
- utilise `ChatModelConfig` comme repli si aucun modèle n'est fourni

## Test
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68981f942960832299e28bb82da89f1b