### PR TITLE
Log SECRET_KEY presence via logger

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -67,10 +67,11 @@ from utils.scheduler_instance import scheduler, start_scheduler, shutdown_schedu
 
 from werkzeug.security import generate_password_hash
 
-from celery_app import celery, init_celery 
+from celery_app import celery, init_celery
 
 # Initialize logger
-logging.basicConfig(level=logging.INFO)
+log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
 logger = logging.getLogger(__name__)
 
 # Load environment variables
@@ -95,7 +96,10 @@ class TestConfig:
 
 def create_app(testing=False):
     load_dotenv()
-    print(f"--- DEBUG: SECRET_KEY lue depuis l'environnement: {os.getenv('SECRET_KEY')} ---")
+    if os.getenv('SECRET_KEY'):
+        logger.debug("SECRET_KEY environment variable is set.")
+    else:
+        logger.warning("SECRET_KEY environment variable is not set.")
     base_path = os.path.dirname(os.path.dirname(__file__))
     app = Flask(
         __name__,


### PR DESCRIPTION
## Summary
- configure logging level via LOG_LEVEL env var
- log whether SECRET_KEY is set without exposing its value

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b05ebd7c8322a244ee96efd2439d