### PR TITLE
Centralize environment configuration

### DIFF
--- a/src/celery_app.py
+++ b/src/celery_app.py
@@ -1,7 +1,7 @@
 # EDxo/src/celery_app.py
-import os
-import logging # Ajouter l'import logging
+import logging  # Ajouter l'import logging
 from celery import Celery
+from config.env import CELERY_BROKER_URL, CELERY_RESULT_BACKEND
 # PAS d'import de create_app ici au niveau module
 
 logger = logging.getLogger(__name__) # Initialiser un logger pour ce module
@@ -9,8 +9,8 @@ logger = logging.getLogger(__name__) # Initialiser un logger pour ce module
 # Fonction pour créer l'instance Celery SANS dépendance immédiate à l'app Flask
 def make_celery_instance():
     """Crée et configure une instance Celery de base."""
-    redis_url = os.getenv('CELERY_BROKER_URL', 'redis://127.0.0.1:6379/0')
-    backend_url = os.getenv('CELERY_RESULT_BACKEND', 'redis://127.0.0.1:6379/0')
+    redis_url = CELERY_BROKER_URL
+    backend_url = CELERY_RESULT_BACKEND
 
     celery_instance = Celery(
         # Nom logique de l'application Celery (à des fins de logs)

--- a/src/config/env.py
+++ b/src/config/env.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+import os
+from dotenv import load_dotenv
+
+# Load environment variables once
+load_dotenv()
+
+# Exposed settings
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+SECRET_KEY = os.getenv("SECRET_KEY")
+RECAPTCHA_PUBLIC_KEY = os.getenv("RECAPTCHA_PUBLIC_KEY")
+RECAPTCHA_PRIVATE_KEY = os.getenv("RECAPTCHA_PRIVATE_KEY")
+MISTRAL_API_KEY = os.getenv("MISTRAL_API_KEY")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_MODEL_SECTION = os.getenv("OPENAI_MODEL_SECTION", "gpt-4.1")
+OPENAI_MODEL_EXTRACTION = os.getenv("OPENAI_MODEL_EXTRACTION", "gpt-4.1-mini")
+CELERY_BROKER_URL = os.getenv('CELERY_BROKER_URL', 'redis://127.0.0.1:6379/0')
+CELERY_RESULT_BACKEND = os.getenv('CELERY_RESULT_BACKEND', 'redis://127.0.0.1:6379/0')
+GUNICORN_WORKER_ID = os.getenv("GUNICORN_WORKER_ID")
+CELERY_WORKER = os.getenv("CELERY_WORKER")
+
+
+def validate() -> None:
+    """Raise a RuntimeError if required environment variables are missing."""
+    missing = [name for name, value in {
+        'SECRET_KEY': SECRET_KEY,
+        'RECAPTCHA_PUBLIC_KEY': RECAPTCHA_PUBLIC_KEY,
+        'RECAPTCHA_PRIVATE_KEY': RECAPTCHA_PRIVATE_KEY,
+    }.items() if not value]
+    if missing:
+        raise RuntimeError(f"Missing required environment variables: {', '.join(missing)}")

--- a/src/utils/scheduler_instance.py
+++ b/src/utils/scheduler_instance.py
@@ -2,10 +2,10 @@ import threading
 from functools import wraps
 import logging
 from datetime import datetime
-import os
 from apscheduler.events import EVENT_JOB_ERROR, EVENT_JOB_EXECUTED
 
 from utils.backup_utils import send_backup_email, get_scheduler_instance, send_backup_email_with_context
+from config.env import GUNICORN_WORKER_ID
 
 from app.models import BackupConfig
 
@@ -23,8 +23,7 @@ def with_scheduler_lock(f):
     return wrapper
 
 def is_main_process():
-    worker_id = os.getenv("GUNICORN_WORKER_ID")
-    return worker_id is None or worker_id == "0"
+    return GUNICORN_WORKER_ID is None or GUNICORN_WORKER_ID == "0"
 
 def start_scheduler():
     if not scheduler.running and is_main_process():

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -10,7 +10,6 @@ import unicodedata
 from jinja2 import Template
 from bs4 import BeautifulSoup
 from docxtpl import DocxTemplate
-from dotenv import load_dotenv
 from flask_wtf import FlaskForm
 from wtforms import StringField, SelectField, TimeField, BooleanField
 from wtforms.validators import DataRequired, Email


### PR DESCRIPTION
## Summary
- add `src/config/env.py` to load `.env` and expose settings
- use centralized env config in app factory, Celery, and scheduler
- validate presence of critical environment variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b4480e808322893a73ac1eb26a2a