### PR TITLE
Ajoute des tests pour get_current_time

### DIFF
--- a/tests/test_system_get_current_time.py
+++ b/tests/test_system_get_current_time.py
@@ -1,0 +1,47 @@
+import pytest
+from werkzeug.security import generate_password_hash
+from .test_app import get_model_by_name, fake_requests_post
+
+
+def create_admin(app):
+    """Create an admin user with is_first_connexion disabled."""
+    with app.app_context():
+        from src.app import db
+        User = get_model_by_name("User", db)
+        admin = User(
+            username="admin",
+            password=generate_password_hash("adminpass"),
+            role="admin",
+            credits=0.0,
+            is_first_connexion=False,
+        )
+        db.session.add(admin)
+        db.session.commit()
+        return admin.id
+
+
+def test_get_current_time_requires_auth(client):
+    """Unauthenticated users should be redirected."""
+    response = client.get("/get_current_time")
+    assert response.status_code == 302
+
+
+def test_get_current_time_returns_json_for_admin(client, app, monkeypatch):
+    """Authenticated admin should receive current time in JSON."""
+    monkeypatch.setattr("requests.post", fake_requests_post)
+    create_admin(app)
+
+    login_data = {
+        "username": "admin",
+        "password": "adminpass",
+        "recaptcha_token": "dummy",
+        "submit": "Se connecter",
+    }
+    login_resp = client.post("/login", data=login_data, follow_redirects=True)
+    assert login_resp.status_code == 200
+
+    response = client.get("/get_current_time")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, dict)
+    assert "current_time_utc" in data


### PR DESCRIPTION
## Summary
- couvre l'endpoint /get_current_time avec un utilisateur admin
- vérifie la redirection des utilisateurs non authentifiés
- valide la réponse JSON contenant `current_time_utc`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898c7f858048322958ad4f7fc03f44c