### PR TITLE
Conserve le modèle des réponses OpenAI

### DIFF
--- a/src/app/models.py
+++ b/src/app/models.py
@@ -216,6 +216,7 @@ class User(UserMixin, db.Model):
     username = db.Column(db.Text, nullable=False)
     password = db.Column(db.Text, nullable=False)
     last_openai_response_id = db.Column(db.String, nullable=True)
+    last_openai_response_model = db.Column(db.String, nullable=True)
     # Nouveaux champs
     image = db.Column(db.Text, nullable=True)
     nom = db.Column(db.Text, nullable=True)

--- a/src/app/routes/chat.py
+++ b/src/app/routes/chat.py
@@ -761,7 +761,7 @@ def send_message():
 
                     # Reset state after tool call processing is complete
                     fn_name = fn_args_str = call_id = tool_result_obj = tool_result_json = None
-                    continue # Move to the next event in the *original* iterator (if any)
+                    break  # Stop processing remaining events from the original stream (they may reference the old response ID)
 
 
                 # ------------ Normal Text (not part of a tool call sequence being processed currently) -------------

--- a/src/app/routes/chat.py
+++ b/src/app/routes/chat.py
@@ -433,7 +433,6 @@ def send_message():
     client = OpenAI(api_key=current_user.openai_key)
     cfg = ChatModelConfig.get_current()
     chat_model = cfg.chat_model or "gpt-4.1-mini"
-    tool_model = cfg.tool_model or chat_model
     reasoning_effort = cfg.reasoning_effort
     verbosity = cfg.verbosity
 
@@ -508,6 +507,9 @@ def send_message():
     # --- Construct Final Input ---
     inp = []
     prev_id = current_user.last_openai_response_id
+    prev_model = getattr(current_user, "last_openai_response_model", None)
+    if prev_id and prev_model:
+        chat_model = prev_model
     print(f"[DEBUG LOG] Constructing API input. prev_id={prev_id}. History items to add={len(history_input)}")
 
     # Add system prompt ONLY if there's no previous ID (start of a conversation state)
@@ -716,7 +718,7 @@ def send_message():
                         if verbosity in {"low", "medium", "high"}:
                             text_params["verbosity"] = verbosity
                         follow_kwargs = dict(
-                            model=tool_model,
+                            model=chat_model,
                             previous_response_id=id_for_followup,
                             input=[{"type": "function_call_output", "call_id": call_id, "output": tool_result_json}],
                             tool_choice="auto",
@@ -820,6 +822,7 @@ def send_message():
                     user_to_update = db.session.get(User, current_user.id)
                     if user_to_update:
                         user_to_update.last_openai_response_id = final_id_to_persist_for_api
+                        user_to_update.last_openai_response_model = chat_model
                         db.session.commit()
                         print(f"[DB LOG] COMMITTED final last_openai_response_id for user {current_user.id} to {final_id_to_persist_for_api}")
                     else:

--- a/src/migrations/versions/3a3d2f1c4b05_add_last_openai_response_model.py
+++ b/src/migrations/versions/3a3d2f1c4b05_add_last_openai_response_model.py
@@ -1,0 +1,19 @@
+"""add last_openai_response_model column"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '3a3d2f1c4b05'
+down_revision = 'b6d007ad4e76'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('User', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('last_openai_response_model', sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('User', schema=None) as batch_op:
+        batch_op.drop_column('last_openai_response_model')

--- a/tests/test_chat_context.py
+++ b/tests/test_chat_context.py
@@ -73,6 +73,7 @@ def test_context_persisted_after_tool_call(client, app, monkeypatch):
     monkeypatch.setattr(chat, "ResponseOutputItemAddedEvent", FakeFunctionCallAddedEvent)
     monkeypatch.setattr(chat, "ResponseFunctionCallArgumentsDeltaEvent", FakeFunctionCallArgumentsDeltaEvent)
     monkeypatch.setattr(chat, "ResponseOutputItemDoneEvent", FakeFunctionCallDoneEvent)
+    monkeypatch.setattr(chat, "ResponseCompletedEvent", FakeResponseCompletedEvent)
     chat.OUTPUT_ITEM_EVENTS = (FakeFunctionCallAddedEvent, FakeFunctionCallDoneEvent)
     chat.TEXT_EVENTS = (FakeTextDeltaEvent, FakeFunctionCallAddedEvent)
 
@@ -98,6 +99,7 @@ def test_context_persisted_after_tool_call(client, app, monkeypatch):
             def gen():
                 yield FakeResponseCreatedEvent("id2")
                 yield FakeTextDeltaEvent("done", "id2")
+                yield FakeResponseCompletedEvent("id2")
             return gen()
 
     monkeypatch.setattr(chat, "safe_openai_stream", fake_safe_openai_stream)
@@ -123,6 +125,7 @@ def test_context_persisted_after_tool_call(client, app, monkeypatch):
         def gen():
             yield FakeResponseCreatedEvent("id3")
             yield FakeTextDeltaEvent("next", "id3")
+            yield FakeResponseCompletedEvent("id3")
         return gen()
 
     monkeypatch.setattr(chat, "safe_openai_stream", fake_safe_openai_stream_second)

--- a/tests/test_chat_context.py
+++ b/tests/test_chat_context.py
@@ -35,6 +35,11 @@ class FakeTextDeltaEvent:
         self.response = SimpleNamespace(id=response_id)
 
 
+class FakeResponseCompletedEvent:
+    def __init__(self, response_id):
+        self.response = SimpleNamespace(id=response_id)
+
+
 def test_context_persisted_after_tool_call(client, app, monkeypatch):
     # Patch reCAPTCHA
     monkeypatch.setattr("requests.post", fake_requests_post)
@@ -95,6 +100,7 @@ def test_context_persisted_after_tool_call(client, app, monkeypatch):
             yield FakeFunctionCallAddedEvent("get_plan_de_cours", "call1", "id1")
             yield FakeFunctionCallArgumentsDeltaEvent("{}", "id1")
             yield FakeFunctionCallDoneEvent("id1")
+            yield FakeResponseCompletedEvent("id1")
         return gen()
 
     monkeypatch.setattr(chat, "OpenAI", FakeOpenAI)

--- a/tests/test_chat_context.py
+++ b/tests/test_chat_context.py
@@ -1,0 +1,132 @@
+import json
+from types import SimpleNamespace
+from werkzeug.security import generate_password_hash
+from .test_app import get_model_by_name, fake_requests_post
+import importlib
+chat = importlib.import_module("src.app.routes.chat")
+
+
+class FakeResponseCreatedEvent:
+    def __init__(self, response_id):
+        self.response = SimpleNamespace(id=response_id)
+
+
+class FakeFunctionCallAddedEvent:
+    def __init__(self, name, call_id, response_id):
+        self.item = SimpleNamespace(type="function_call", name=name, call_id=call_id)
+        self.response = SimpleNamespace(id=response_id)
+
+
+class FakeFunctionCallArgumentsDeltaEvent:
+    def __init__(self, delta, response_id):
+        self.delta = delta
+        self.response = SimpleNamespace(id=response_id)
+
+
+class FakeFunctionCallDoneEvent:
+    def __init__(self, response_id):
+        self.item = SimpleNamespace(type="function_call")
+        self.response = SimpleNamespace(id=response_id)
+
+
+class FakeTextDeltaEvent:
+    def __init__(self, text, response_id):
+        self.delta = text
+        self.response = SimpleNamespace(id=response_id)
+
+
+def test_context_persisted_after_tool_call(client, app, monkeypatch):
+    # Patch reCAPTCHA
+    monkeypatch.setattr("requests.post", fake_requests_post)
+
+    with app.app_context():
+        from src.app import db
+        User = get_model_by_name("User", db)
+        ChatModelConfig = get_model_by_name("ChatModelConfig", db)
+        user = User(
+            username="u",
+            password=generate_password_hash("p"),
+            role="admin",
+            credits=0.0,
+            is_first_connexion=False,
+            openai_key="test"
+        )
+        db.session.add(user)
+        db.session.commit()
+        user_id = user.id
+        cfg = ChatModelConfig.get_current()
+        cfg.chat_model = "model-chat"
+        cfg.tool_model = "model-tool"
+        db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(user_id)
+        sess['_fresh'] = True
+
+    # Patch event classes
+    monkeypatch.setattr(chat, "ResponseCreatedEvent", FakeResponseCreatedEvent)
+    monkeypatch.setattr(chat, "ResponseOutputItemAddedEvent", FakeFunctionCallAddedEvent)
+    monkeypatch.setattr(chat, "ResponseFunctionCallArgumentsDeltaEvent", FakeFunctionCallArgumentsDeltaEvent)
+    monkeypatch.setattr(chat, "ResponseOutputItemDoneEvent", FakeFunctionCallDoneEvent)
+    chat.OUTPUT_ITEM_EVENTS = (FakeFunctionCallAddedEvent, FakeFunctionCallDoneEvent)
+    chat.TEXT_EVENTS = (FakeTextDeltaEvent, FakeFunctionCallAddedEvent)
+
+    # Patch tool handler
+    monkeypatch.setattr(chat, "handle_get_plan_de_cours", lambda args: {"ok": True})
+
+    captured_follow_kwargs = {}
+
+    class FakeOpenAI:
+        def __init__(self, api_key=None):
+            self.api_key = api_key
+            self.responses = self
+
+        def create(self, **kwargs):
+            nonlocal captured_follow_kwargs
+            captured_follow_kwargs = kwargs
+            def gen():
+                yield FakeResponseCreatedEvent("id2")
+                yield FakeTextDeltaEvent("done", "id2")
+            return gen()
+
+    def fake_safe_openai_stream(**kwargs):
+        def gen():
+            yield FakeResponseCreatedEvent("id1")
+            yield FakeFunctionCallAddedEvent("get_plan_de_cours", "call1", "id1")
+            yield FakeFunctionCallArgumentsDeltaEvent("{}", "id1")
+            yield FakeFunctionCallDoneEvent("id1")
+        return gen()
+
+    monkeypatch.setattr(chat, "OpenAI", FakeOpenAI)
+    monkeypatch.setattr(chat, "safe_openai_stream", fake_safe_openai_stream)
+
+    response = client.post("/chat/send", json={"message": "hello"})
+    assert response.status_code == 200
+    response.get_data()
+    assert captured_follow_kwargs["model"] == "model-chat"
+    assert captured_follow_kwargs["previous_response_id"] == "id1"
+
+    with app.app_context():
+        from src.app import db
+        User = get_model_by_name("User", db)
+        user = User.query.filter_by(username="u").first()
+        assert user.last_openai_response_id == "id2"
+        assert user.last_openai_response_model == "model-chat"
+
+    captured_second_kwargs = {}
+
+    def fake_safe_openai_stream_second(**kwargs):
+        nonlocal captured_second_kwargs
+        captured_second_kwargs = kwargs
+        def gen():
+            yield FakeResponseCreatedEvent("id3")
+            yield FakeTextDeltaEvent("next", "id3")
+        return gen()
+
+    monkeypatch.setattr(chat, "safe_openai_stream", fake_safe_openai_stream_second)
+
+    response2 = client.post("/chat/send", json={"message": "again"})
+    assert response2.status_code == 200
+    response2.get_data()
+    assert captured_second_kwargs["previous_response_id"] == "id2"
+    assert captured_second_kwargs["model"] == "model-chat"


### PR DESCRIPTION
## Summary
- Stocke l'identifiant de réponse OpenAI avec le modèle utilisé
- Réutilise le même modèle pour les appels suivants, y compris après un tool call
- Ajoute un test garantissant que le contexte est conservé après l'exécution d'un outil

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e51747a88322a8b65bde470c49a8