### PR TITLE
Ajoute un test pour l'estimation de tokens

### DIFF
--- a/tests/chat/test_estimate_tokens.py
+++ b/tests/chat/test_estimate_tokens.py
@@ -1,0 +1,24 @@
+import tiktoken
+from src.app.routes.chat import estimate_tokens_for_text
+
+
+class DummyEncoding:
+    def encode(self, text: str):
+        return text.split()
+
+
+def test_estimate_tokens_for_text_fallback(monkeypatch):
+    def mock_encoding_for_model(model):
+        raise KeyError("unknown model")
+
+    def mock_get_encoding(name):
+        assert name == "cl100k_base"
+        return DummyEncoding()
+
+    monkeypatch.setattr(tiktoken, "encoding_for_model", mock_encoding_for_model)
+    monkeypatch.setattr(tiktoken, "get_encoding", mock_get_encoding)
+
+    text = "Un petit test de tokenisation"
+    manual_count = len(text.split())
+    estimated = estimate_tokens_for_text(text, model="modele-fictif")
+    assert estimated == manual_count


### PR DESCRIPTION
## Summary
- test fallback cl100k_base dans estimate_tokens_for_text

## Testing
- `pytest tests/chat/test_estimate_tokens.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e61e048083229aea3c125687e892