### PR TITLE
Ajoute tests pour process_changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ python-dotenv
 mistralai
 openai
 Flask
+Flask-Session

--- a/tests/utils/test_db_tracking.py
+++ b/tests/utils/test_db_tracking.py
@@ -1,0 +1,48 @@
+from src.app import db
+from src.utils.db_tracking import process_changes
+
+
+class Dummy(db.Model):
+    __tablename__ = 'dummy'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(50))
+    value = db.Column(db.Integer)
+
+
+def test_process_changes_insert(app):
+    obj = Dummy(name='alpha', value=1)
+    db.session.add(obj)
+    db.session.flush()
+    changes = process_changes(Dummy.__mapper__, obj, 'INSERT')
+    assert 'new_values' in changes
+    assert changes['new_values'] == {
+        'id': str(obj.id),
+        'name': 'alpha',
+        'value': '1',
+    }
+
+
+def test_process_changes_update(app):
+    obj = Dummy(name='alpha', value=1)
+    db.session.add(obj)
+    db.session.commit()
+    obj = Dummy.query.first()
+    obj.name = 'beta'
+    obj.value = 2
+    changes = process_changes(Dummy.__mapper__, obj, 'UPDATE')
+    assert changes['old_values'] == {'name': 'alpha', 'value': 1}
+    assert changes['new_values'] == {'name': 'beta', 'value': 2}
+
+
+def test_process_changes_delete(app):
+    obj = Dummy(name='alpha', value=1)
+    db.session.add(obj)
+    db.session.commit()
+    obj = Dummy.query.first()
+    db.session.delete(obj)
+    changes = process_changes(Dummy.__mapper__, obj, 'DELETE')
+    assert changes['deleted_values'] == {
+        'id': str(obj.id),
+        'name': 'alpha',
+        'value': '1',
+    }


### PR DESCRIPTION
## Summary
- ajoute un modèle minimal et des tests pour `process_changes`
- déclare la dépendance Flask-Session manquante

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e6207b44832291e2a7bfd9bf96d4