### PR TITLE
Ajoute génération automatique du calendrier

### DIFF
--- a/src/app/init/prompt_settings.py
+++ b/src/app/init/prompt_settings.py
@@ -111,6 +111,10 @@ La définition doit:
 - Être alignée avec les politiques institutionnelles
 - Être formulée de manière claire et précise""",
                 'context_variables': ['current_value', 'cours_id']
+            },
+            'calendrier': {
+                'template': """Tu es un assistant pédagogique. Génère un calendrier hebdomadaire des activités pour la session {session} en te basant sur les informations suivantes du plan-cadre:\n{sections}\nLe résultat doit être un JSON avec une liste 'calendriers' contenant pour chaque semaine les champs semaine, sujet, activites, travaux_hors_classe et evaluations.""",
+                'context_variables': ['session', 'sections']
             }
         }
 

--- a/src/app/routes/plan_de_cours.py
+++ b/src/app/routes/plan_de_cours.py
@@ -415,7 +415,7 @@ def view_plan_de_cours(cours_id, session=None):
 
             # Copier les calendriers
             for cal in source_plan.calendriers:
-                new_cal = PlanDeCours(
+                new_cal = PlanDeCoursCalendrier(
                     semaine=cal.semaine,
                     sujet=cal.sujet,
                     activites=cal.activites,
@@ -604,7 +604,7 @@ def view_plan_de_cours(cours_id, session=None):
                     # Calendriers
                     plan_de_cours.calendriers.clear()
                     for cal_f in form.calendriers.entries:
-                        new_cal = PlanDeCours(
+                        new_cal = PlanDeCoursCalendrier(
                             semaine=cal_f.data.get("semaine"),
                             sujet=cal_f.data.get("sujet"),
                             activites=cal_f.data.get("activites"),

--- a/src/app/routes/plan_de_cours.py
+++ b/src/app/routes/plan_de_cours.py
@@ -290,8 +290,16 @@ def generate_calendar():
     if user.credits <= 0:
         return jsonify({'error': 'Crédits insuffisants. Veuillez recharger votre compte.'}), 403
 
-    ai_model = 'gpt-4o'
-    prompt = build_calendar_prompt(plan_cadre, session)
+    prompt_settings = PlanDeCoursPromptSettings.query.filter_by(
+        field_name='calendrier'
+    ).first()
+    if not prompt_settings:
+        return jsonify({'error': 'Configuration de prompt manquante pour le calendrier.'}), 500
+
+    ai_model = prompt_settings.ai_model or 'gpt-4o'
+    prompt = build_calendar_prompt(
+        plan_cadre, session, prompt_settings.prompt_template
+    )
 
     try:
         client = OpenAI(api_key=current_user.openai_key)

--- a/src/app/routes/plan_de_cours.py
+++ b/src/app/routes/plan_de_cours.py
@@ -223,7 +223,7 @@ def generate_content():
         response = client.responses.parse(
             model=ai_model,
             input=prompt,
-            response_format=AIPlandeCoursResponse,
+            text_format=AIPlandeCoursResponse,
         )
 
         usage_prompt = response.usage.input_tokens if hasattr(response, 'usage') else 0
@@ -298,7 +298,7 @@ def generate_calendar():
         response = client.responses.parse(
             model=ai_model,
             input=prompt,
-            response_format=CalendarResponse,
+            text_format=CalendarResponse,
         )
 
         usage_prompt = response.usage.input_tokens if hasattr(response, 'usage') else 0

--- a/src/app/templates/view_plan_de_cours.html
+++ b/src/app/templates/view_plan_de_cours.html
@@ -310,7 +310,12 @@
 
                         <!-- Calendrier -->
                         <div class="mb-3">
-                            <h4>Calendrier des activités</h4>
+                            <div class="d-flex align-items-center justify-content-between">
+                                <h4 class="mb-0">Calendrier des activités</h4>
+                                <button type="button" class="btn btn-secondary btn-sm generate-calendar" id="generate-calendar" title="Générer le calendrier">
+                                    <i class="bi bi-magic"></i>Générer le calendrier
+                                </button>
+                            </div>
                             <div id="calendrier-container" class="mb-3" {% if not form.calendriers %}style="display: none;"{% endif %}>
                                  {% for subform in form.calendriers %}
                                     <div class="calendar-item border p-2 mb-2 {% if loop.index0 is even %}bg-light{% else %}bg-secondary text-white{% endif %}" draggable="true">
@@ -349,10 +354,7 @@
                                     </div>
                                 {% endfor %}
                             </div>
-                            <div class="d-flex justify-content-end gap-2">
-                                <button type="button" class="btn btn-secondary btn-sm generate-calendar" id="generate-calendar" title="Générer le calendrier">
-                                    <i class="bi bi-magic"></i>Générer le calendrier
-                                </button>
+                            <div class="d-flex justify-content-end">
                                 <button type="button" class="btn btn-success btn-sm" id="add-calendrier" title="Ajouter">
                                     <i class="bi bi-plus-circle"></i>
                                 </button>
@@ -1236,6 +1238,7 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('generate-calendar')?.addEventListener('click', async function() {
         const button = this;
         const container = document.getElementById('calendrier-container');
+        container.style.display = 'block';
 
         // Ajouter overlay de chargement
         const loadingOverlay = document.createElement('div');

--- a/src/app/templates/view_plan_de_cours.html
+++ b/src/app/templates/view_plan_de_cours.html
@@ -349,7 +349,10 @@
                                     </div>
                                 {% endfor %}
                             </div>
-                            <div class="d-flex justify-content-end">
+                            <div class="d-flex justify-content-end gap-2">
+                                <button type="button" class="btn btn-primary btn-sm" id="generate-calendrier">
+                                    Générer le calendrier
+                                </button>
                                 <button type="button" class="btn btn-success btn-sm" id="add-calendrier" title="Ajouter">
                                     <i class="bi bi-plus-circle"></i>
                                 </button>
@@ -1227,6 +1230,61 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Initialiser le drag & drop au chargement
     initDragAndDrop();
+
+    // Génération automatique du calendrier via l'IA
+    document.getElementById('generate-calendrier')?.addEventListener('click', async function() {
+        const button = this;
+        button.disabled = true;
+        const container = document.getElementById('calendrier-container');
+        try {
+            const payload = {
+                cours_id: {{ cours.id }},
+                session: "{{ plan_de_cours.session }}"
+            };
+            const response = await fetch("{{ url_for('plan_de_cours.generate_calendar') }}", {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': "{{ csrf_token() }}"
+                },
+                body: JSON.stringify(payload),
+                credentials: 'same-origin'
+            });
+
+            if (!response.ok) {
+                const err = await response.json();
+                throw new Error(err.error || 'Erreur inconnue');
+            }
+
+            const data = await response.json();
+            container.innerHTML = '';
+            if (data.entries && data.entries.length > 0) {
+                container.style.display = 'block';
+                data.entries.forEach((entry, index) => {
+                    const newItem = document.createElement('div');
+                    newItem.className = `calendar-item border p-2 mb-2 ${index % 2 === 0 ? 'bg-light' : 'bg-secondary text-white'}`;
+                    newItem.innerHTML = document.getElementById('calendrier-template').innerHTML.replace(/__index__/g, index);
+                    newItem.querySelector(`[name="calendriers-${index}-semaine"]`).value = entry.semaine ?? '';
+                    newItem.querySelector(`[name="calendriers-${index}-sujet"]`).value = entry.sujet ?? '';
+                    newItem.querySelector(`[name="calendriers-${index}-activites"]`).value = entry.activites ?? '';
+                    newItem.querySelector(`[name="calendriers-${index}-travaux_hors_classe"]`).value = entry.travaux_hors_classe ?? '';
+                    newItem.querySelector(`[name="calendriers-${index}-evaluations"]`).value = entry.evaluations ?? '';
+                    container.appendChild(newItem);
+                });
+                calendrierIndex = data.entries.length;
+                initDragAndDrop();
+                window.showFloatingButtons();
+                showToast('generateSuccessToast');
+            } else {
+                showToast('generateErrorToast');
+            }
+        } catch (error) {
+            console.error('Erreur lors de la génération du calendrier:', error);
+            showToast('generateErrorToast');
+        } finally {
+            button.disabled = false;
+        }
+    });
 
     // Gestion du bouton d'ajout de calendrier
     document.getElementById('add-calendrier')?.addEventListener('click', function() {

--- a/src/app/templates/view_plan_de_cours.html
+++ b/src/app/templates/view_plan_de_cours.html
@@ -350,8 +350,8 @@
                                 {% endfor %}
                             </div>
                             <div class="d-flex justify-content-end gap-2">
-                                <button type="button" class="btn btn-secondary btn-sm generate-calendar" id="generate-calendrier" title="Générer automatiquement">
-                                    <i class="bi bi-magic"></i>Générer automatiquement
+                                <button type="button" class="btn btn-secondary btn-sm generate-calendar" id="generate-calendar" title="Générer le calendrier">
+                                    <i class="bi bi-magic"></i>Générer le calendrier
                                 </button>
                                 <button type="button" class="btn btn-success btn-sm" id="add-calendrier" title="Ajouter">
                                     <i class="bi bi-plus-circle"></i>
@@ -1233,7 +1233,7 @@ document.addEventListener('DOMContentLoaded', function() {
     initDragAndDrop();
 
     // Génération automatique du calendrier via l'IA
-    document.getElementById('generate-calendrier')?.addEventListener('click', async function() {
+    document.getElementById('generate-calendar')?.addEventListener('click', async function() {
         const button = this;
         const container = document.getElementById('calendrier-container');
 

--- a/src/app/templates/view_plan_de_cours.html
+++ b/src/app/templates/view_plan_de_cours.html
@@ -350,8 +350,8 @@
                                 {% endfor %}
                             </div>
                             <div class="d-flex justify-content-end gap-2">
-                                <button type="button" class="btn btn-primary btn-sm" id="generate-calendrier">
-                                    Générer le calendrier
+                                <button type="button" class="btn btn-secondary btn-sm generate-calendar" id="generate-calendrier" title="Générer automatiquement">
+                                    <i class="bi bi-magic"></i>Générer automatiquement
                                 </button>
                                 <button type="button" class="btn btn-success btn-sm" id="add-calendrier" title="Ajouter">
                                     <i class="bi bi-plus-circle"></i>
@@ -775,7 +775,8 @@ textarea.toast-ui-target:not(.toast-initialized) {
     position: relative;
 }
 
-.generate-button.loading {
+.generate-button.loading,
+.generate-calendar.loading {
     pointer-events: none;
     opacity: 0.7;
 }
@@ -1234,8 +1235,23 @@ document.addEventListener('DOMContentLoaded', function() {
     // Génération automatique du calendrier via l'IA
     document.getElementById('generate-calendrier')?.addEventListener('click', async function() {
         const button = this;
-        button.disabled = true;
         const container = document.getElementById('calendrier-container');
+
+        // Ajouter overlay de chargement
+        const loadingOverlay = document.createElement('div');
+        loadingOverlay.className = 'loading-overlay';
+        loadingOverlay.innerHTML = `
+            <div class="loading-dots">
+                <span></span>
+                <span></span>
+                <span></span>
+                <div class="loading-text">Génération en cours...</div>
+            </div>
+        `;
+        container.style.position = 'relative';
+        container.appendChild(loadingOverlay);
+        button.classList.add('loading');
+        button.disabled = true;
         try {
             const payload = {
                 cours_id: {{ cours.id }},
@@ -1257,6 +1273,10 @@ document.addEventListener('DOMContentLoaded', function() {
             }
 
             const data = await response.json();
+            const overlay = container.querySelector('.loading-overlay');
+            if (overlay) {
+                overlay.remove();
+            }
             container.innerHTML = '';
             if (data.entries && data.entries.length > 0) {
                 container.style.display = 'block';
@@ -1282,6 +1302,11 @@ document.addEventListener('DOMContentLoaded', function() {
             console.error('Erreur lors de la génération du calendrier:', error);
             showToast('generateErrorToast');
         } finally {
+            const overlay = container.querySelector('.loading-overlay');
+            if (overlay) {
+                overlay.remove();
+            }
+            button.classList.remove('loading');
             button.disabled = false;
         }
     });

--- a/src/utils/calendar_generator.py
+++ b/src/utils/calendar_generator.py
@@ -52,11 +52,17 @@ def build_calendar_prompt(
     # Champs principaux du plan cadre
     sections.extend(
         [
+            f"Place du cours: {plan_cadre.place_intro or ''}",
             f"Objectif terminal: {plan_cadre.objectif_terminal or ''}",
             f"Structure du cours: {plan_cadre.structure_intro or ''}",
             f"Activités théoriques: {plan_cadre.structure_activites_theoriques or ''}",
             f"Activités pratiques: {plan_cadre.structure_activites_pratiques or ''}",
             f"Activités prévues: {plan_cadre.structure_activites_prevues or ''}",
+            f"Évaluation sommative: {plan_cadre.eval_evaluation_sommative or ''}",
+            f"Nature des évaluations sommatives: {plan_cadre.eval_nature_evaluations_sommatives or ''}",
+            f"Évaluation de la langue: {plan_cadre.eval_evaluation_de_la_langue or ''}",
+            f"Évaluation sommative des apprentissages: {plan_cadre.eval_evaluation_sommatives_apprentissages or ''}",
+            f"Informations additionnelles: {plan_cadre.additional_info or ''}",
         ]
     )
 
@@ -74,13 +80,11 @@ def build_calendar_prompt(
         )
 
         cap_lines.append(
-            (
-                f"Capacité: {capacite.capacite or ''}. {capacite.description_capacite or ''}. "
-                f"Pondération: {capacite.ponderation_min or ''}-{capacite.ponderation_max or ''}. "
-                f"Savoirs nécessaires: {savoirs_necessaires}. "
-                f"Savoirs faire: {savoirs_faire}. "
-                f"Moyens d'évaluation: {moyens_eval}.",
-            )
+            f"Capacité: {capacite.capacite or ''}. {capacite.description_capacite or ''}. "
+            f"Pondération: {capacite.ponderation_min or ''}-{capacite.ponderation_max or ''}. "
+            f"Savoirs nécessaires: {savoirs_necessaires}. "
+            f"Savoirs faire: {savoirs_faire}. "
+            f"Moyens d'évaluation: {moyens_eval}."
         )
 
     if cap_lines:

--- a/src/utils/calendar_generator.py
+++ b/src/utils/calendar_generator.py
@@ -42,10 +42,10 @@ def build_calendar_prompt(plan_cadre, session: str) -> str:
     sections.extend(
         [
             f"Objectif terminal: {plan_cadre.objectif_terminal or ''}",
-            f"Structure des activités théoriques: {plan_cadre.structure_activites_theoriques or ''}",
-            f"Structure des activités pratiques: {plan_cadre.structure_activites_pratiques or ''}",
+            f"Structure du cours: {plan_cadre.structure_intro or ''}",
+            f"Activités théoriques: {plan_cadre.structure_activites_theoriques or ''}",
+            f"Activités pratiques: {plan_cadre.structure_activites_pratiques or ''}",
             f"Activités prévues: {plan_cadre.structure_activites_prevues or ''}",
-            f"Évaluations sommatives: {plan_cadre.eval_evaluation_sommative or ''}",
         ]
     )
 

--- a/src/utils/calendar_generator.py
+++ b/src/utils/calendar_generator.py
@@ -25,16 +25,55 @@ def build_calendar_prompt(plan_cadre, session: str) -> str:
     """Construit le prompt d'appel à l'API OpenAI pour générer un calendrier.
 
     Le prompt s'appuie sur diverses sections du plan cadre ainsi que sur la
-    session ciblée afin d'obtenir un calendrier hebdomadaire détaillé.
+    session ciblée afin d'obtenir un calendrier hebdomadaire détaillé. Les
+    informations incluent les données du cours et les capacités avec leurs
+    composantes, jugées essentielles pour un découpage pertinent du calendrier.
     """
 
-    sections = [
-        f"Objectif terminal: {plan_cadre.objectif_terminal or ''}",
-        f"Structure des activités théoriques: {plan_cadre.structure_activites_theoriques or ''}",
-        f"Structure des activités pratiques: {plan_cadre.structure_activites_pratiques or ''}",
-        f"Activités prévues: {plan_cadre.structure_activites_prevues or ''}",
-        f"Évaluations sommatives: {plan_cadre.eval_evaluation_sommative or ''}",
-    ]
+    sections = []
+
+    # Informations générales sur le cours
+    if getattr(plan_cadre, "cours", None):
+        sections.append(
+            f"Cours: {plan_cadre.cours.code or ''} - {plan_cadre.cours.nom or ''}"
+        )
+
+    # Champs principaux du plan cadre
+    sections.extend(
+        [
+            f"Objectif terminal: {plan_cadre.objectif_terminal or ''}",
+            f"Structure des activités théoriques: {plan_cadre.structure_activites_theoriques or ''}",
+            f"Structure des activités pratiques: {plan_cadre.structure_activites_pratiques or ''}",
+            f"Activités prévues: {plan_cadre.structure_activites_prevues or ''}",
+            f"Évaluations sommatives: {plan_cadre.eval_evaluation_sommative or ''}",
+        ]
+    )
+
+    # Capacités détaillées
+    cap_lines: List[str] = []
+    for capacite in getattr(plan_cadre, "capacites", []) or []:
+        savoirs_necessaires = ", ".join(
+            sn.texte for sn in getattr(capacite, "savoirs_necessaires", []) if sn.texte
+        )
+        savoirs_faire = ", ".join(
+            sf.texte for sf in getattr(capacite, "savoirs_faire", []) if sf.texte
+        )
+        moyens_eval = ", ".join(
+            me.texte for me in getattr(capacite, "moyens_evaluation", []) if me.texte
+        )
+
+        cap_lines.append(
+            (
+                f"Capacité: {capacite.capacite or ''}. {capacite.description_capacite or ''}. "
+                f"Pondération: {capacite.ponderation_min or ''}-{capacite.ponderation_max or ''}. "
+                f"Savoirs nécessaires: {savoirs_necessaires}. "
+                f"Savoirs faire: {savoirs_faire}. "
+                f"Moyens d'évaluation: {moyens_eval}."
+            )
+        )
+
+    if cap_lines:
+        sections.append("Capacités:\n" + "\n".join(cap_lines))
 
     prompt = (
         "Tu es un assistant pédagogique. Génère un calendrier hebdomadaire "

--- a/src/utils/calendar_generator.py
+++ b/src/utils/calendar_generator.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class CalendarEntry(BaseModel):
+    """Représente une ligne du calendrier généré."""
+
+    semaine: Optional[int] = None
+    sujet: Optional[str] = None
+    activites: Optional[str] = None
+    travaux_hors_classe: Optional[str] = None
+    evaluations: Optional[str] = None
+
+
+class CalendarResponse(BaseModel):
+    """Structure attendue de la réponse de l'API."""
+
+    calendriers: List[CalendarEntry] = Field(default_factory=list)
+
+
+def build_calendar_prompt(plan_cadre, session: str) -> str:
+    """Construit le prompt d'appel à l'API OpenAI pour générer un calendrier.
+
+    Le prompt s'appuie sur diverses sections du plan cadre ainsi que sur la
+    session ciblée afin d'obtenir un calendrier hebdomadaire détaillé.
+    """
+
+    sections = [
+        f"Objectif terminal: {plan_cadre.objectif_terminal or ''}",
+        f"Structure des activités théoriques: {plan_cadre.structure_activites_theoriques or ''}",
+        f"Structure des activités pratiques: {plan_cadre.structure_activites_pratiques or ''}",
+        f"Activités prévues: {plan_cadre.structure_activites_prevues or ''}",
+        f"Évaluations sommatives: {plan_cadre.eval_evaluation_sommative or ''}",
+    ]
+
+    prompt = (
+        "Tu es un assistant pédagogique. Génère un calendrier hebdomadaire "
+        "des activités pour la session {session}.\n"
+        "Base-toi sur les informations du plan-cadre ci-dessous pour proposer "
+        "un déroulement cohérent du cours.\n"
+        "Plan-cadre:\n{sections}\n\n"
+        "Le résultat doit être un JSON avec une liste 'calendriers'. Chaque "
+        "élément comporte les champs: semaine (int), sujet, activites, "
+        "travaux_hors_classe et evaluations."
+    ).format(session=session, sections="\n".join(sections))
+
+    return prompt

--- a/tests/test_calendar_generator.py
+++ b/tests/test_calendar_generator.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+from src.utils.calendar_generator import build_calendar_prompt
+
+
+def _simple(text: str):
+    return SimpleNamespace(texte=text)
+
+
+def test_build_calendar_prompt_includes_plan_cadre_sections():
+    plan_cadre = SimpleNamespace(
+        cours=SimpleNamespace(code="MATH101", nom="Mathématiques"),
+        place_intro="Position du cours",
+        objectif_terminal="Objectif X",
+        structure_intro="Structure Y",
+        structure_activites_theoriques="Théorie",
+        structure_activites_pratiques="Pratique",
+        structure_activites_prevues="Prévu",
+        eval_evaluation_sommative="Exam final",
+        eval_nature_evaluations_sommatives="Tests",
+        eval_evaluation_de_la_langue="Éval langue",
+        eval_evaluation_sommatives_apprentissages="Synthèse",
+        additional_info="Notes diverses",
+        capacites=[
+            SimpleNamespace(
+                capacite="Cap1",
+                description_capacite="Desc",
+                ponderation_min=10,
+                ponderation_max=30,
+                savoirs_necessaires=[_simple("SN1")],
+                savoirs_faire=[_simple("SF1")],
+                moyens_evaluation=[_simple("ME1")],
+            )
+        ],
+    )
+
+    prompt = build_calendar_prompt(plan_cadre, "A25")
+
+    assert "Capacité: Cap1" in prompt
+    assert "Objectif terminal: Objectif X" in prompt
+    assert "Évaluation sommative: Exam final" in prompt
+    assert "SN1" in prompt


### PR DESCRIPTION
## Résumé
- Génère un prompt IA basé sur le plan-cadre via `calendar_generator`
- Ajoute la route `/generate_calendar` avec gestion des crédits et sauvegarde des entrées
- Utilise désormais l’API `responses` pour la génération (calendrier et champs)

## Tests
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cabdfec048322a7e23c3ee4ce9d5d