### PR TITLE
Affiche le résumé du raisonnement lors de la génération du plan cadre

### DIFF
--- a/src/app/routes/plan_cadre.py
+++ b/src/app/routes/plan_cadre.py
@@ -129,6 +129,7 @@ def review_improvement(plan_id):
         return redirect(url_for('cours.view_plan_cadre', cours_id=PlanCadre.query.get(plan_id).cours_id, plan_id=plan_id))
 
     proposed = res.result.get('proposed', {})
+    reasoning_summary = res.result.get('reasoning_summary')
     plan = PlanCadre.query.get(plan_id)
     if not plan:
         flash('Plan Cadre non trouvé.', 'danger')
@@ -218,7 +219,8 @@ def review_improvement(plan_id):
         cours=plan.cours,
         plan_id=plan_id,
         task_id=task_id,
-        changes=changes
+        changes=changes,
+        reasoning_summary=reasoning_summary
     )
 
 

--- a/src/app/tasks/generation_plan_cadre.py
+++ b/src/app/tasks/generation_plan_cadre.py
@@ -712,13 +712,17 @@ def generate_plan_cadre_content_task(self, plan_id, form_data, user_id):
                 text=text_params,
                 store=True,
             )
+            reasoning_params = {"summary": "auto"}
             if reasoning_effort in {"minimal", "low", "medium", "high"}:
-                request_kwargs["reasoning"] = {"effort": reasoning_effort}
+                reasoning_params["effort"] = reasoning_effort
+            request_kwargs["reasoning"] = reasoning_params
 
             # Streaming if requested by client
             do_stream = str(form_data.get("stream") or "0").lower() in ("1", "true", "yes", "on")
             streamed_text = None
             response = None
+            reasoning_items = []
+            reasoning_summary_text = ""
             if do_stream:
                 try:
                     request_kwargs_stream = dict(request_kwargs)
@@ -740,8 +744,20 @@ def generate_plan_cadre_content_task(self, plan_id, form_data, user_id):
                                         'seq': seq
                                     })
                                     logger.info("Stream chunk %s: %s", seq, delta)
+                            elif etype.startswith('reasoning') and getattr(event, 'summary', None):
+                                reasoning_items.extend(event.summary)
                             elif etype.endswith('response.completed') or etype == 'response.completed':
                                 break
+                        if reasoning_items:
+                            for item in reasoning_items:
+                                if getattr(item, 'type', '') == 'summary_text':
+                                    reasoning_summary_text += getattr(item, 'text', '')
+                            reasoning_summary_text = reasoning_summary_text.strip()
+                            if reasoning_summary_text:
+                                self.update_state(state='PROGRESS', meta={
+                                    'message': 'Résumé du raisonnement',
+                                    'reasoning_summary': reasoning_summary_text
+                                })
                         response = stream.get_final_response()
                 except Exception as se:
                     logging.warning(f"Streaming non disponible, bascule vers mode non-stream: {se}")
@@ -751,6 +767,22 @@ def generate_plan_cadre_content_task(self, plan_id, form_data, user_id):
             # Non-stream or fallback: perform standard request
             if streamed_text is None:
                 response = client.responses.create(**request_kwargs)
+                if hasattr(response, 'reasoning') and response.reasoning:
+                    reasoning_items = []
+                    for r in response.reasoning:
+                        summary = getattr(r, 'summary', None)
+                        if summary:
+                            reasoning_items.extend(summary)
+                    if reasoning_items:
+                        for item in reasoning_items:
+                            if getattr(item, 'type', '') == 'summary_text':
+                                reasoning_summary_text += getattr(item, 'text', '')
+                        reasoning_summary_text = reasoning_summary_text.strip()
+                        if reasoning_summary_text:
+                            self.update_state(state='PROGRESS', meta={
+                                'message': 'Résumé du raisonnement',
+                                'reasoning_summary': reasoning_summary_text
+                            })
         except Exception as e:
             logging.error(f"OpenAI error: {e}")
             result_meta = {"status": "error", "message": f"Erreur API OpenAI: {str(e)}"}
@@ -957,6 +989,8 @@ def generate_plan_cadre_content_task(self, plan_id, form_data, user_id):
             }
             if streamed_text:
                 result["stream_buffer"] = streamed_text
+            if reasoning_summary_text:
+                result["reasoning_summary"] = reasoning_summary_text
             self.update_state(state="SUCCESS", meta=result)
             return result
         else:
@@ -969,6 +1003,8 @@ def generate_plan_cadre_content_task(self, plan_id, form_data, user_id):
             }
             if streamed_text:
                 result["stream_buffer"] = streamed_text
+            if reasoning_summary_text:
+                result["reasoning_summary"] = reasoning_summary_text
             self.update_state(state="SUCCESS", meta=result)
             return result
 

--- a/src/app/templates/review_plan_cadre_improvement.html
+++ b/src/app/templates/review_plan_cadre_improvement.html
@@ -4,6 +4,10 @@
   <h2>Revoir les améliorations proposées — {{ cours.code }} - {{ cours.nom }}</h2>
   <p class="text-muted">Comparez les changements avant de les appliquer définitivement.</p>
 
+  {% if reasoning_summary %}
+    <div class="alert alert-secondary"><strong>Résumé du raisonnement :</strong> {{ reasoning_summary }}</div>
+  {% endif %}
+
   {% if changes|length == 0 %}
     <div class="alert alert-info">Aucun changement proposé par rapport au contenu actuel.</div>
   {% else %}

--- a/src/app/templates/view_plan_cadre.html
+++ b/src/app/templates/view_plan_cadre.html
@@ -962,6 +962,7 @@
                             <label class="form-label">Aperçu en direct</label>
                             <div class="small text-muted mb-1" id="streamStatus"></div>
                             <pre id="streamOutput" class="form-control" style="height: 240px; overflow:auto; background:#f9f9f9"></pre>
+                            <div class="small text-muted mt-2" id="reasoningSummary"></div>
                         </div>
                     </div>
                     <div class="modal-footer">

--- a/src/static/js/view_plan_cadre.js
+++ b/src/static/js/view_plan_cadre.js
@@ -669,16 +669,20 @@ document.addEventListener('DOMContentLoaded', function() {
                     const container = document.getElementById('streamContainer');
                     const out = document.getElementById('streamOutput');
                     const status = document.getElementById('streamStatus');
+                    const summary = document.getElementById('reasoningSummary');
                     if (container && out) {
                         out.textContent = '';
                         container.classList.remove('d-none');
+                        if (summary) summary.textContent = '';
                     }
                     window.onTaskStreamUpdate = function(meta) {
                         try {
                             if (!meta) return;
                             const out = document.getElementById('streamOutput');
                             const status = document.getElementById('streamStatus');
+                            const summary = document.getElementById('reasoningSummary');
                             if (status && meta.message) status.textContent = meta.message;
+                            if (summary && meta.reasoning_summary) summary.textContent = meta.reasoning_summary;
                             if (out) {
                                 if (meta.stream_buffer) {
                                     out.textContent = meta.stream_buffer;


### PR DESCRIPTION
## Summary
- Ajoute l'affichage du résumé de raisonnement dans la page de révision des améliorations.
- Affiche le résumé de raisonnement dans l'aperçu en direct lors des requêtes d'amélioration ou de génération.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d4ccdbca4832292b64533b0fdb77f