### PR TITLE
Expose API endpoints for programmes and course plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Ceci est une application web Flask. L'application est structurée de manière mo
 6. [Tests](#tests)
 7. [Déploiement](#déploiement)
 8. [Structure-du-projet](#structure-du-projet)
-9. [Licence](#licence)
+9. [API et OAuth](#api-et-oauth)
+10. [Licence](#licence)
 
 ## 1. Fonctionnalités
 
@@ -24,6 +25,7 @@ Ceci est une application web Flask. L'application est structurée de manière mo
 - **Planification des sauvegardes** : Planification automatique des sauvegardes de la base de données grâce à APScheduler.
 - **Gestion des sessions** : Expiration automatique des sessions en fonction de l'activité.
 - **Outils supplémentaires** : limitation du débit avec Flask-Limiter, et bien d'autres.
+- **API REST sécurisée** : Accès aux programmes, cours et plans via un jeton personnel ou un flux OAuth 2.1 (PKCE, enregistrement dynamique). Un serveur MCP fournit également ces données via le protocole Model Context Protocol.
 
 ## 2. Prérequis
 
@@ -232,7 +234,7 @@ sudo systemctl start edxo-celery.service
 ```
 
 
-## 10. Structure du projet
+## Structure du projet
 ```
 edxo/
 ├── src/
@@ -249,7 +251,34 @@ edxo/
 └── README.md                   # Ce fichier
 ```
 
-## 11. Licence
+## API et OAuth
+
+### Jeton personnel
+
+Depuis l'interface web, ouvrez <em>Paramètres → Espace développeur</em> pour générer un jeton lié à votre compte. Ce jeton peut recevoir une durée de vie personnalisée et doit être envoyé dans l'en-tête <code>X-API-Token</code> de chaque requête.
+
+```bash
+curl -H "X-API-Token: VOTRE_TOKEN" https://example.com/api/programmes
+```
+
+La page <code>/help/api</code> liste l'ensemble des points d'accès disponibles.
+
+### Flux OAuth 2.1
+
+Pour les applications externes, l'API prend en charge le flux Authorization Code avec PKCE et l'enregistrement dynamique des clients.
+
+- Métadonnées : <code>GET /.well-known/oauth-authorization-server</code>
+- Inscription client : <code>POST /register</code>
+- Autorisation utilisateur : <code>GET /authorize</code>
+- Échange de code : <code>POST /token</code>
+
+Les jetons émis sont liés à l'utilisateur qui a accordé l'accès et peuvent être présentés à l'API via <code>Authorization: Bearer &lt;token&gt;</code>.
+
+### Serveur MCP
+
+Le serveur FastMCP (« <code>src/mcp_server/server.py</code> ») expose les mêmes données via le protocole Model Context Protocol. Il accepte les jetons personnels ou OAuth dans l'en-tête <code>Authorization</code>.
+
+## Licence
 Ce projet est sous licence MIT.
 
 N'hésitez pas à contribuer en ouvrant des issues ou en soumettant des pull requests. Pour toute question, veuillez contacter francis.poisson2@gmail.com.

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ mistralai
 openai
 Flask
 Flask-Session
+fastmcp

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -55,6 +55,7 @@ from .routes.system import system_bp
 from .routes.ocr_routes import ocr_bp
 from .routes.grilles import grille_bp
 from .routes.api import api_bp
+from .routes.oauth import oauth_bp
 
 # Import version
 from ..config.version import __version__
@@ -226,6 +227,7 @@ def create_app(testing=False):
     app.register_blueprint(ocr_bp)
     app.register_blueprint(grille_bp)
     app.register_blueprint(api_bp)
+    app.register_blueprint(oauth_bp)
 
     # Register helpers and handlers
     @app.context_processor
@@ -240,6 +242,7 @@ def create_app(testing=False):
             request.endpoint == 'static' or
             request.path.startswith('/static/') or
             request.path.startswith('/api/') or
+            request.path.startswith('/oauth/') or
             (view_func is not None and getattr(view_func, 'is_public', False))
         ):
             return

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -246,7 +246,8 @@ def create_app(testing=False):
             request.endpoint == 'static' or
             request.path.startswith('/static/') or
             request.path.startswith('/api/') or
-            request.path.startswith('/oauth/') or
+            request.path in ('/token', '/register') or
+            request.path.startswith('/.well-known/') or
             (view_func is not None and getattr(view_func, 'is_public', False))
         ):
             return

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -56,6 +56,7 @@ from .routes.ocr_routes import ocr_bp
 from .routes.grilles import grille_bp
 from .routes.api import api_bp
 from .routes.oauth import oauth_bp
+from ..mcp_server.server import init_app as init_mcp_server
 
 # Import version
 from ..config.version import __version__
@@ -204,6 +205,9 @@ def create_app(testing=False):
     ckeditor.init_app(app)
     csrf.init_app(app)
     init_change_tracking(db)
+
+    # Bind Flask app to MCP server for OAuth verification
+    init_mcp_server(app)
 
     if not testing:
         migrate = Migrate(app, db)

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -54,6 +54,7 @@ from .routes.settings import settings_bp
 from .routes.system import system_bp
 from .routes.ocr_routes import ocr_bp
 from .routes.grilles import grille_bp
+from .routes.api import api_bp
 
 # Import version
 from ..config.version import __version__
@@ -224,6 +225,7 @@ def create_app(testing=False):
     app.register_blueprint(gestion_programme_bp)
     app.register_blueprint(ocr_bp)
     app.register_blueprint(grille_bp)
+    app.register_blueprint(api_bp)
 
     # Register helpers and handlers
     @app.context_processor
@@ -237,6 +239,7 @@ def create_app(testing=False):
         if (
             request.endpoint == 'static' or
             request.path.startswith('/static/') or
+            request.path.startswith('/api/') or
             (view_func is not None and getattr(view_func, 'is_public', False))
         ):
             return

--- a/src/app/forms.py
+++ b/src/app/forms.py
@@ -746,6 +746,10 @@ class DeleteForm(FlaskForm):
     """Simple form for CSRF protection on delete operations"""
     pass
 
+class APITokenForm(FlaskForm):
+    ttl = IntegerField('Durée de vie (jours)', validators=[Optional()])
+    submit = SubmitField('Générer un jeton')
+
 class OcrTriggerForm(FlaskForm):
     pdf_url = URLField('URL du PDF', validators=[DataRequired(), URL()])
     pdf_title = StringField('Titre (Optionnel)', validators=[Optional(), Length(max=100)])

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -301,10 +301,28 @@ class OAuthToken(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     token = db.Column(db.String(64), unique=True, nullable=False)
     client_id = db.Column(db.String(64), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('User.id'), nullable=True)
     expires_at = db.Column(db.DateTime, nullable=False)
+
+    user = db.relationship('User')
 
     def is_valid(self):
         return self.expires_at > datetime.utcnow()
+
+
+class OAuthAuthorizationCode(db.Model):
+    """Code d'autorisation temporaire pour le flux Authorization Code."""
+
+    __tablename__ = 'oauth_authorization_code'
+    id = db.Column(db.Integer, primary_key=True)
+    code = db.Column(db.String(64), unique=True, nullable=False)
+    client_id = db.Column(db.String(64), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('User.id'), nullable=False)
+    code_challenge = db.Column(db.String(128), nullable=False)
+    expires_at = db.Column(db.DateTime, nullable=False)
+
+    user = db.relationship('User')
+
 
 # ------------------------------------------------------------------------------
 # Modèles liés aux compétences et éléments de compétences

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+from datetime import datetime, timedelta
+import secrets
 
 import sys
 
@@ -234,6 +235,8 @@ class User(UserMixin, db.Model):
     credits = db.Column(db.Float, nullable=False, default=0.0)
     email = db.Column(db.String(120), nullable=True)
     last_login = db.Column(db.DateTime, nullable=True)
+    api_token = db.Column(db.String(64), unique=True, nullable=True)
+    api_token_expires_at = db.Column(db.DateTime, nullable=True)
 
     reset_version = db.Column(db.Integer, default=0)  # Champ pour invalider les anciens tokens
 
@@ -262,6 +265,12 @@ class User(UserMixin, db.Model):
         if user and user.reset_version == token_reset_version:
             return user
         return None
+
+    def generate_api_token(self, expires_in=30 * 24 * 3600):
+        self.api_token = secrets.token_hex(16)
+        self.api_token_expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
+        db.session.commit()
+        return self.api_token
     
     __table_args__ = (
         UniqueConstraint('email', name='uq_user_email'),

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -277,9 +277,34 @@ class User(UserMixin, db.Model):
     )
 
     # Relations
-    programmes = db.relationship('Programme', 
+    programmes = db.relationship('Programme',
                                secondary=user_programme,
                                backref=db.backref('users', lazy='dynamic'))
+
+
+class OAuthClient(db.Model):
+    """Client OAuth enregistré dynamiquement."""
+
+    __tablename__ = 'oauth_client'
+    id = db.Column(db.Integer, primary_key=True)
+    client_id = db.Column(db.String(64), unique=True, nullable=False)
+    client_secret = db.Column(db.String(64), nullable=False)
+    name = db.Column(db.String(120), nullable=True)
+    redirect_uri = db.Column(db.String(255), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class OAuthToken(db.Model):
+    """Jeton d'accès OAuth simple."""
+
+    __tablename__ = 'oauth_token'
+    id = db.Column(db.Integer, primary_key=True)
+    token = db.Column(db.String(64), unique=True, nullable=False)
+    client_id = db.Column(db.String(64), nullable=False)
+    expires_at = db.Column(db.DateTime, nullable=False)
+
+    def is_valid(self):
+        return self.expires_at > datetime.utcnow()
 
 # ------------------------------------------------------------------------------
 # Modèles liés aux compétences et éléments de compétences

--- a/src/app/routes/api.py
+++ b/src/app/routes/api.py
@@ -39,6 +39,8 @@ def api_auth_required(f):
             oauth = OAuthToken.query.filter_by(token=bearer).first()
             if oauth and oauth.is_valid():
                 g.api_client = oauth.client_id
+                if oauth.user:
+                    g.api_user = oauth.user
                 return f(*args, **kwargs)
             return jsonify({'error': 'Unauthorized'}), 401
         if current_user.is_authenticated:

--- a/src/app/routes/api.py
+++ b/src/app/routes/api.py
@@ -1,0 +1,213 @@
+"""API endpoints for core operations."""
+
+from functools import wraps
+from datetime import datetime, timedelta
+import secrets
+
+from flask import Blueprint, jsonify, send_file, request, g
+from flask_login import current_user, login_required
+
+from ..models import (
+    Programme,
+    Cours,
+    Competence,
+    PlanCadre,
+    PlanDeCours,
+    User,
+    db,
+)
+
+api_bp = Blueprint('api', __name__, url_prefix='/api')
+
+
+def api_auth_required(f):
+    """Allow access with logged in user or valid X-API-Token header."""
+
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        token = request.headers.get('X-API-Token')
+        if token is not None:
+            user = User.query.filter_by(api_token=token).first()
+            if user and user.api_token_expires_at and user.api_token_expires_at > datetime.utcnow():
+                g.api_user = user
+                return f(*args, **kwargs)
+            return jsonify({'error': 'Unauthorized'}), 401
+        if current_user.is_authenticated:
+            g.api_user = current_user
+            return f(*args, **kwargs)
+        return jsonify({'error': 'Unauthorized'}), 401
+
+    return decorated
+
+
+@api_bp.route('/token', methods=['GET', 'POST'])
+@login_required
+def api_token():
+    """Return or generate an API token for the current user."""
+    user = current_user
+    if request.method == 'POST':
+        ttl = request.args.get('ttl', type=int)
+        expires_in = ttl if ttl is not None else 30 * 24 * 3600
+        user.generate_api_token(expires_in=expires_in)
+        status = 201
+    elif not user.api_token or not user.api_token_expires_at or user.api_token_expires_at <= datetime.utcnow():
+        user.generate_api_token(expires_in=30 * 24 * 3600)
+        status = 201
+    else:
+        status = 200
+    return (
+        jsonify(
+            {
+                'token': user.api_token,
+                'expires_at': user.api_token_expires_at.isoformat(),
+            }
+        ),
+        status,
+    )
+
+
+@api_bp.get('/programmes')
+@api_auth_required
+def list_programmes():
+    programmes = Programme.query.all()
+    data = [{'id': p.id, 'nom': p.nom} for p in programmes]
+    return jsonify(data)
+
+
+@api_bp.get('/programmes/<int:programme_id>/cours')
+@api_auth_required
+def list_courses_for_program(programme_id):
+    programme = Programme.query.get_or_404(programme_id)
+    courses = [{'id': c.id, 'code': c.code, 'nom': c.nom} for c in programme.cours]
+    return jsonify(courses)
+
+
+@api_bp.get('/programmes/<int:programme_id>/competences')
+@api_auth_required
+def list_competences_for_program(programme_id):
+    competences = Competence.query.filter_by(programme_id=programme_id).order_by(Competence.code).all()
+    data = [{'id': c.id, 'code': c.code, 'nom': c.nom} for c in competences]
+    return jsonify(data)
+
+
+@api_bp.get('/competences/<int:competence_id>')
+@api_auth_required
+def competence_details(competence_id):
+    comp = Competence.query.get_or_404(competence_id)
+    elements = [
+        {
+            'id': e.id,
+            'nom': e.nom,
+            'criteres': [c.criteria for c in e.criteria]
+        }
+        for e in comp.elements
+    ]
+    return jsonify({
+        'id': comp.id,
+        'programme_id': comp.programme_id,
+        'code': comp.code,
+        'nom': comp.nom,
+        'criteria_de_performance': comp.criteria_de_performance,
+        'contexte_de_realisation': comp.contexte_de_realisation,
+        'elements': elements
+    })
+
+
+@api_bp.get('/cours')
+@api_auth_required
+def list_courses():
+    courses = Cours.query.all()
+    data = [{'id': c.id, 'code': c.code, 'nom': c.nom} for c in courses]
+    return jsonify(data)
+
+
+@api_bp.get('/cours/<int:cours_id>')
+@api_auth_required
+def course_details(cours_id):
+    cours = Cours.query.get_or_404(cours_id)
+    return jsonify({'id': cours.id, 'code': cours.code, 'nom': cours.nom})
+
+
+@api_bp.get('/cours/<int:cours_id>/plan_cadre')
+@api_auth_required
+def plan_cadre_details(cours_id):
+    plan = PlanCadre.query.filter_by(cours_id=cours_id).first()
+    if not plan:
+        return jsonify({}), 404
+    return jsonify(plan.to_dict())
+
+
+@api_bp.get('/cours/<int:cours_id>/plans_de_cours')
+@api_auth_required
+def plans_de_cours_list(cours_id):
+    plans = PlanDeCours.query.filter_by(cours_id=cours_id).all()
+    return jsonify([p.to_dict() for p in plans])
+
+
+@api_bp.post('/plan_cadre/<int:plan_id>/generate')
+@api_auth_required
+def generate_plan_cadre(plan_id):
+    from ..tasks.generation_plan_cadre import generate_plan_cadre_content_task
+    task = generate_plan_cadre_content_task.delay(plan_id, {}, g.api_user.id)
+    return jsonify({'task_id': task.id}), 202
+
+
+@api_bp.post('/plan_de_cours/<int:plan_id>/generate')
+@api_auth_required
+def generate_plan_de_cours(plan_id):
+    from ..tasks.generation_plan_de_cours import generate_plan_de_cours_all_task
+    task = generate_plan_de_cours_all_task.delay(plan_id, '', 'gpt-4o', g.api_user.id)
+    return jsonify({'task_id': task.id}), 202
+
+
+@api_bp.post('/plan_cadre/<int:plan_id>/improve')
+@api_auth_required
+def improve_plan_cadre(plan_id):
+    from ..tasks.generation_plan_cadre import generate_plan_cadre_content_task
+    payload = {'improve_only': True}
+    task = generate_plan_cadre_content_task.delay(plan_id, payload, g.api_user.id)
+    return jsonify({'task_id': task.id}), 202
+
+
+@api_bp.post('/plan_cadre/<int:plan_id>/improve/<string:section>')
+@api_auth_required
+def improve_plan_cadre_section(plan_id, section):
+    from ..tasks.generation_plan_cadre import generate_plan_cadre_content_task
+    payload = {'improve_only': True, 'target_columns': [section]}
+    task = generate_plan_cadre_content_task.delay(plan_id, payload, g.api_user.id)
+    return jsonify({'task_id': task.id}), 202
+
+
+@api_bp.get('/plan_cadre/<int:plan_id>/section/<string:section>')
+@api_auth_required
+def get_plan_cadre_section(plan_id, section):
+    plan = PlanCadre.query.get_or_404(plan_id)
+    if not hasattr(plan, section):
+        return jsonify({'error': 'Section inconnue'}), 404
+    return jsonify({section: getattr(plan, section)})
+
+
+@api_bp.get('/plan_cadre/<int:plan_id>/export_docx')
+@api_auth_required
+def export_plan_cadre_docx(plan_id):
+    from ...utils import generate_docx_with_template
+    plan = PlanCadre.query.get_or_404(plan_id)
+    docx_file = generate_docx_with_template(plan_id)
+    if not docx_file:
+        return jsonify({'error': 'generation failed'}), 400
+    safe_course_name = plan.cours.nom.replace(' ', '_') if plan.cours else 'Plan_Cadre'
+    filename = f"Plan_Cadre_{plan.cours.code}_{safe_course_name}.docx" if plan.cours else f"Plan_Cadre_{plan.id}.docx"
+    return send_file(
+        docx_file,
+        as_attachment=True,
+        download_name=filename,
+        mimetype='application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    )
+
+
+@api_bp.get('/plan_de_cours/<int:plan_id>/export_docx')
+@api_auth_required
+def export_plan_de_cours_docx(plan_id):
+    from .plan_de_cours import export_docx as export_pdc
+    plan = PlanDeCours.query.get_or_404(plan_id)
+    return export_pdc(plan.cours_id, plan.session)

--- a/src/app/routes/oauth.py
+++ b/src/app/routes/oauth.py
@@ -3,11 +3,26 @@
 from datetime import datetime, timedelta
 import secrets
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, url_for
 
 from ..models import OAuthClient, OAuthToken, db
 
-oauth_bp = Blueprint('oauth', __name__, url_prefix='/oauth')
+oauth_bp = Blueprint('oauth', __name__)
+
+
+@oauth_bp.get('/.well-known/oauth-authorization-server')
+def oauth_metadata():
+    """Expose OAuth server metadata for discovery."""
+    return (
+        jsonify(
+            {
+                'issuer': request.url_root.rstrip('/'),
+                'token_endpoint': url_for('oauth.issue_token', _external=True),
+                'registration_endpoint': url_for('oauth.register_client', _external=True),
+            }
+        ),
+        200,
+    )
 
 
 @oauth_bp.post('/register')

--- a/src/app/routes/oauth.py
+++ b/src/app/routes/oauth.py
@@ -1,0 +1,47 @@
+"""OAuth endpoints for dynamic client registration and token issuance."""
+
+from datetime import datetime, timedelta
+import secrets
+
+from flask import Blueprint, jsonify, request
+
+from ..models import OAuthClient, OAuthToken, db
+
+oauth_bp = Blueprint('oauth', __name__, url_prefix='/oauth')
+
+
+@oauth_bp.post('/register')
+def register_client():
+    """Register a new OAuth client and return credentials."""
+    data = request.get_json() or {}
+    name = data.get('name')
+    redirect_uri = data.get('redirect_uri')
+    client_id = secrets.token_hex(16)
+    client_secret = secrets.token_hex(32)
+    client = OAuthClient(
+        client_id=client_id,
+        client_secret=client_secret,
+        name=name,
+        redirect_uri=redirect_uri,
+    )
+    db.session.add(client)
+    db.session.commit()
+    return jsonify({'client_id': client_id, 'client_secret': client_secret}), 201
+
+
+@oauth_bp.post('/token')
+def issue_token():
+    """Issue an access token for a registered client."""
+    data = request.get_json() or {}
+    client_id = data.get('client_id')
+    client_secret = data.get('client_secret')
+    client = OAuthClient.query.filter_by(client_id=client_id, client_secret=client_secret).first()
+    if not client:
+        return jsonify({'error': 'invalid_client'}), 401
+    ttl = data.get('ttl', 3600)
+    token = secrets.token_hex(16)
+    expires_at = datetime.utcnow() + timedelta(seconds=ttl)
+    oauth_token = OAuthToken(token=token, client_id=client_id, expires_at=expires_at)
+    db.session.add(oauth_token)
+    db.session.commit()
+    return jsonify({'access_token': token, 'token_type': 'bearer', 'expires_in': ttl}), 200

--- a/src/app/routes/routes.py
+++ b/src/app/routes/routes.py
@@ -434,9 +434,13 @@ def change_password():
     return render_template('change_password.html', form=form)
 
 @main.route('/')
-@login_required
+@public_route
 @ensure_profile_completed
 def index():
+    if not current_user.is_authenticated:
+        form = LoginForm()
+        return render_template('login.html', form=form)
+
     # Récupérer l'utilisateur connecté
     user = current_user
     

--- a/src/app/routes/routes.py
+++ b/src/app/routes/routes.py
@@ -92,6 +92,12 @@ def health():
     except Exception:
         return jsonify({'status': 'degraded'}), 200
 
+
+@main.route('/help/api')
+@login_required
+def api_help_page():
+    return render_template('help/api.html')
+
 @main.route('/forgot-password', methods=['GET', 'POST'])
 @public_route
 def forgot_password():

--- a/src/app/routes/settings.py
+++ b/src/app/routes/settings.py
@@ -15,6 +15,7 @@ from ..forms import (
     PlanDeCoursPromptSettingsForm,
     OpenAIModelForm,
     ChatSettingsForm,
+    APITokenForm,
 )
 from .evaluation import AISixLevelGridResponse
 from ...config.constants import SECTIONS  # Importer la liste des sections
@@ -107,6 +108,23 @@ def chat_model_settings():
     # Assurer l'affichage cohérent: refléter le couplage côté formulaire
     form.tool_model.data = config.chat_model
     return render_template('settings/chat_models.html', form=form)
+
+
+@settings_bp.route('/developer', methods=['GET', 'POST'])
+@login_required
+def developer():
+    form = APITokenForm()
+    if form.validate_on_submit():
+        days = form.ttl.data or 30
+        current_user.generate_api_token(expires_in=days * 24 * 3600)
+        flash('Jeton API généré.', 'success')
+        return redirect(url_for('settings.developer'))
+    return render_template(
+        'settings/developer.html',
+        form=form,
+        token=current_user.api_token,
+        expires_at=current_user.api_token_expires_at,
+    )
 
 @settings_bp.route('/edit_profile', methods=['GET', 'POST'])
 @login_required

--- a/src/app/templates/help/api.html
+++ b/src/app/templates/help/api.html
@@ -1,0 +1,42 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Documentation de l'API</h1>
+<p>Pour utiliser l'API, générez un jeton personnel depuis l'<a href="{{ url_for('settings.developer') }}">espace développeur</a>.
+Incluez ce jeton dans l'en-tête <code>X-API-Token</code> de chaque requête.</p>
+<table class="table">
+  <thead>
+    <tr><th>Méthode</th><th>Endpoint</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>GET</td><td>/api/programmes</td><td>Liste des programmes</td></tr>
+    <tr><td>GET</td><td>/api/programmes/&lt;id&gt;/cours</td><td>Cours d'un programme</td></tr>
+    <tr><td>GET</td><td>/api/programmes/&lt;id&gt;/competences</td><td>Compétences ministérielles du programme</td></tr>
+    <tr><td>GET</td><td>/api/competences/&lt;id&gt;</td><td>Détails d'une compétence</td></tr>
+    <tr><td>GET</td><td>/api/cours</td><td>Liste de tous les cours</td></tr>
+    <tr><td>GET</td><td>/api/cours/&lt;id&gt;</td><td>Détails d'un cours</td></tr>
+    <tr><td>GET</td><td>/api/cours/&lt;id&gt;/plan_cadre</td><td>Plan cadre d'un cours</td></tr>
+    <tr><td>GET</td><td>/api/cours/&lt;id&gt;/plans_de_cours</td><td>Plans de cours d'un cours</td></tr>
+    <tr><td>POST</td><td>/api/plan_cadre/&lt;id&gt;/generate</td><td>Générer un plan cadre</td></tr>
+    <tr><td>POST</td><td>/api/plan_de_cours/&lt;id&gt;/generate</td><td>Générer un plan de cours</td></tr>
+    <tr><td>POST</td><td>/api/plan_cadre/&lt;id&gt;/improve</td><td>Améliorer un plan cadre</td></tr>
+    <tr><td>POST</td><td>/api/plan_cadre/&lt;id&gt;/improve/&lt;section&gt;</td><td>Améliorer une section du plan cadre</td></tr>
+    <tr><td>GET</td><td>/api/plan_cadre/&lt;id&gt;/section/&lt;section&gt;</td><td>Récupérer une section du plan cadre</td></tr>
+    <tr><td>GET</td><td>/api/plan_cadre/&lt;id&gt;/export_docx</td><td>Exporter un plan cadre en DOCX</td></tr>
+    <tr><td>GET</td><td>/api/plan_de_cours/&lt;id&gt;/export_docx</td><td>Exporter un plan de cours en DOCX</td></tr>
+  </tbody>
+</table>
+
+<h2>Exemples d'utilisation</h2>
+<p>Les requêtes ci-dessous utilisent <code>curl</code>. Remplacez <code>VOTRE_TOKEN</code> par le jeton obtenu et adaptez les identifiants.</p>
+
+<h3>Liste des programmes</h3>
+<pre><code>curl -H "X-API-Token: VOTRE_TOKEN" {{ url_for('api.list_programmes', _external=True) }}</code></pre>
+
+<h3>Détails d'un cours</h3>
+<pre><code>curl -H "X-API-Token: VOTRE_TOKEN" {{ url_for('api.course_details', cours_id=1, _external=True) }}</code></pre>
+
+<h3>Générer un plan cadre</h3>
+<pre><code>curl -X POST -H "X-API-Token: VOTRE_TOKEN" {{ url_for('api.generate_plan_cadre', plan_id=1, _external=True) }}</code></pre>
+
+<p>Les points d'accès de génération retournent un identifiant de tâche Celery. Utilisez l'interface de l'application pour suivre leur progression.</p>
+{% endblock %}

--- a/src/app/templates/help/api.html
+++ b/src/app/templates/help/api.html
@@ -3,6 +3,7 @@
 <h1>Documentation de l'API</h1>
 <p>Pour utiliser l'API, générez un jeton personnel depuis l'<a href="{{ url_for('settings.developer') }}">espace développeur</a>.
 Incluez ce jeton dans l'en-tête <code>X-API-Token</code> de chaque requête.</p>
+<p>Le serveur MCP accepte également ce jeton via <code>Authorization: Bearer &lt;token&gt;</code>.</p>
 <table class="table">
   <thead>
     <tr><th>Méthode</th><th>Endpoint</th><th>Description</th></tr>

--- a/src/app/templates/oauth/authorize.html
+++ b/src/app/templates/oauth/authorize.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Autoriser {{ client.name or client.client_id }}</h1>
+<form method="post">
+  <input type="hidden" name="code_challenge" value="{{ code_challenge }}" />
+  <p>Cette application demande l'accès à votre compte.</p>
+  <button type="submit" name="confirm" value="yes" class="btn btn-primary">Autoriser</button>
+</form>
+{% endblock %}

--- a/src/app/templates/parametres.html
+++ b/src/app/templates/parametres.html
@@ -34,6 +34,10 @@
                         <i class="bi bi-key me-2"></i>
                         <span>Modifier le mot de passe</span>
                       </a>
+                      <a href="{{ url_for('settings.developer') }}" class="list-group-item list-group-item-action d-flex align-items-center">
+                        <i class="bi bi-code-slash me-2"></i>
+                        <span>Espace développeur</span>
+                      </a>
                     </div>
                   </div>
                 </div>

--- a/src/app/templates/settings/developer.html
+++ b/src/app/templates/settings/developer.html
@@ -1,0 +1,22 @@
+{% extends "parametres.html" %}
+{% block parametres_content %}
+<h1>Espace développeur</h1>
+<p>Générez ici un jeton personnel pour accéder à l'API. Le jeton doit être inclus dans l'en-tête <code>X-API-Token</code> de vos requêtes.</p>
+{% if token %}
+<p><strong>Jeton actuel :</strong> <code>{{ token }}</code></p>
+{% if expires_at %}
+<p><strong>Expire le :</strong> {{ expires_at }}</p>
+{% endif %}
+{% else %}
+<p>Aucun jeton généré pour l'instant.</p>
+{% endif %}
+<form method="post">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">
+    {{ form.ttl.label }}
+    {{ form.ttl(class="form-control", placeholder="30") }}
+    <small class="form-text text-muted">Durée en jours (par défaut 30).</small>
+  </div>
+  {{ form.submit(class="btn btn-primary") }}
+</form>
+{% endblock %}

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -1,0 +1,97 @@
+"""MCP server exposing programme and course resources."""
+
+from fastmcp import FastMCP
+
+from src.app.models import (
+    Programme,
+    Cours,
+    Competence,
+    PlanCadre,
+    PlanDeCours,
+)
+
+mcp = FastMCP(name="EDxoMCP")
+
+
+def programmes():
+    """Retourne la liste des programmes."""
+    return [{"id": p.id, "nom": p.nom} for p in Programme.query.all()]
+
+
+def programme_courses(programme_id: int):
+    """Cours associés à un programme."""
+    programme = Programme.query.get(programme_id)
+    if not programme:
+        raise ValueError("Programme introuvable")
+    return [{"id": c.id, "code": c.code, "nom": c.nom} for c in programme.cours]
+
+
+def programme_competences(programme_id: int):
+    """Compétences ministérielles d'un programme."""
+    comps = Competence.query.filter_by(programme_id=programme_id).order_by(Competence.code).all()
+    return [{"id": c.id, "code": c.code, "nom": c.nom} for c in comps]
+
+
+def competence_details(competence_id: int):
+    """Détails d'une compétence."""
+    comp = Competence.query.get(competence_id)
+    if not comp:
+        raise ValueError("Compétence introuvable")
+    elements = [
+        {"id": e.id, "nom": e.nom, "criteres": [c.criteria for c in e.criteria]}
+        for e in comp.elements
+    ]
+    return {
+        "id": comp.id,
+        "programme_id": comp.programme_id,
+        "code": comp.code,
+        "nom": comp.nom,
+        "criteria_de_performance": comp.criteria_de_performance,
+        "contexte_de_realisation": comp.contexte_de_realisation,
+        "elements": elements,
+    }
+
+
+def cours():
+    """Liste de tous les cours."""
+    return [{"id": c.id, "code": c.code, "nom": c.nom} for c in Cours.query.all()]
+
+
+def cours_details(cours_id: int):
+    """Informations sur un cours."""
+    cours_obj = Cours.query.get(cours_id)
+    if not cours_obj:
+        raise ValueError("Cours introuvable")
+    return {"id": cours_obj.id, "code": cours_obj.code, "nom": cours_obj.nom}
+
+
+def cours_plan_cadre(cours_id: int):
+    """Plan cadre lié à un cours."""
+    plan = PlanCadre.query.filter_by(cours_id=cours_id).first()
+    return plan.to_dict() if plan else {}
+
+
+def cours_plans_de_cours(cours_id: int):
+    """Plans de cours associés à un cours."""
+    plans = PlanDeCours.query.filter_by(cours_id=cours_id).all()
+    return [p.to_dict() for p in plans]
+
+
+def plan_cadre_section(plan_id: int, section: str):
+    """Récupère une section spécifique d'un plan cadre."""
+    plan = PlanCadre.query.get(plan_id)
+    if not plan or not hasattr(plan, section):
+        raise ValueError("Section inconnue")
+    return {section: getattr(plan, section)}
+
+
+# Enregistrement des ressources auprès du serveur MCP
+mcp.resource("api://programmes")(programmes)
+mcp.resource("api://programmes/{programme_id}/cours")(programme_courses)
+mcp.resource("api://programmes/{programme_id}/competences")(programme_competences)
+mcp.resource("api://competences/{competence_id}")(competence_details)
+mcp.resource("api://cours")(cours)
+mcp.resource("api://cours/{cours_id}")(cours_details)
+mcp.resource("api://cours/{cours_id}/plan_cadre")(cours_plan_cadre)
+mcp.resource("api://cours/{cours_id}/plans_de_cours")(cours_plans_de_cours)
+mcp.resource("api://plan_cadre/{plan_id}/section/{section}")(plan_cadre_section)

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -95,3 +95,58 @@ mcp.resource("api://cours/{cours_id}")(cours_details)
 mcp.resource("api://cours/{cours_id}/plan_cadre")(cours_plan_cadre)
 mcp.resource("api://cours/{cours_id}/plans_de_cours")(cours_plans_de_cours)
 mcp.resource("api://plan_cadre/{plan_id}/section/{section}")(plan_cadre_section)
+
+
+def search(query: str):
+    """Recherche des programmes et cours par nom."""
+    results = []
+    for p in Programme.query.filter(Programme.nom.ilike(f"%{query}%")).all():
+        results.append({
+            "id": f"programme:{p.id}",
+            "title": p.nom,
+            "text": p.nom,
+            "url": f"/api/programmes/{p.id}",
+        })
+    for c in Cours.query.filter(Cours.nom.ilike(f"%{query}%")).all():
+        results.append({
+            "id": f"cours:{c.id}",
+            "title": c.nom,
+            "text": c.nom,
+            "url": f"/api/cours/{c.id}",
+        })
+    return results
+
+
+def fetch(item_id: str):
+    """Récupère le contenu complet d'un résultat de recherche."""
+    try:
+        kind, _id = item_id.split(":", 1)
+        _id = int(_id)
+    except ValueError:
+        raise ValueError("identifiant invalide")
+    if kind == "programme":
+        p = Programme.query.get(_id)
+        if not p:
+            raise ValueError("programme introuvable")
+        return {
+            "id": item_id,
+            "title": p.nom,
+            "text": p.nom,
+            "url": f"/api/programmes/{p.id}",
+        }
+    if kind == "cours":
+        c = Cours.query.get(_id)
+        if not c:
+            raise ValueError("cours introuvable")
+        return {
+            "id": item_id,
+            "title": c.nom,
+            "text": c.nom,
+            "url": f"/api/cours/{c.id}",
+        }
+    raise ValueError("type inconnu")
+
+
+# Enregistrement des outils
+mcp.tool(search)
+mcp.tool(fetch)

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,0 +1,162 @@
+from datetime import datetime, timedelta
+from werkzeug.security import generate_password_hash
+from src.app import db
+from src.app.models import (
+    Programme,
+    Department,
+    Cours,
+    PlanCadre,
+    PlanDeCours,
+    Competence,
+    User,
+)
+
+
+def setup_data(app):
+    with app.app_context():
+        dept = Department(nom="Dep")
+        db.session.add(dept)
+        db.session.commit()
+
+        programme = Programme(nom="Prog", department_id=dept.id)
+        db.session.add(programme)
+        db.session.commit()
+
+        cours = Cours(code="C101", nom="Course", heures_theorie=0,
+                      heures_laboratoire=0, heures_travail_maison=0)
+        db.session.add(cours)
+        db.session.commit()
+        cours.programmes.append(programme)
+        db.session.commit()
+
+        plan_cadre = PlanCadre(cours_id=cours.id)
+        db.session.add(plan_cadre)
+        plan_de_cours = PlanDeCours(cours_id=cours.id, session="A25")
+        db.session.add(plan_de_cours)
+
+        comp = Competence(programme_id=programme.id, code="COMP1", nom="Comp 1")
+        db.session.add(comp)
+        db.session.commit()
+
+        return programme.id, cours.id, plan_cadre.id, plan_de_cours.id, comp.id
+
+
+def create_user(app, programmes=None, token="api-token", expires_in_days=1):
+    with app.app_context():
+        user = User(
+            username="tester",
+            password=generate_password_hash("password"),
+            role="admin",
+            credits=0.0,
+            is_first_connexion=False,
+            api_token=token,
+            api_token_expires_at=datetime.utcnow() + timedelta(days=expires_in_days),
+        )
+        if programmes:
+            for pid in programmes:
+                programme = db.session.get(Programme, pid)
+                if programme:
+                    user.programmes.append(programme)
+        db.session.add(user)
+        db.session.commit()
+        return user.id, token
+
+
+def test_api_endpoints(app, client):
+    prog_id, cours_id, plan_cadre_id, plan_de_cours_id, comp_id = setup_data(app)
+    user_id, token = create_user(app, programmes=[prog_id])
+
+    # unauthorized request without token
+    resp = client.get("/api/programmes")
+    assert resp.status_code == 401
+
+    headers = {"X-API-Token": token}
+
+    resp = client.get("/api/programmes", headers=headers)
+    assert resp.status_code == 200
+    assert any(p["id"] == prog_id for p in resp.get_json())
+
+    resp = client.get(f"/api/programmes/{prog_id}/cours", headers=headers)
+    assert resp.status_code == 200
+    assert resp.get_json()[0]["id"] == cours_id
+
+    resp = client.get(f"/api/programmes/{prog_id}/competences", headers=headers)
+    assert resp.status_code == 200
+    assert resp.get_json()[0]["code"] == "COMP1"
+
+    resp = client.get(f"/api/competences/{comp_id}", headers=headers)
+    assert resp.status_code == 200
+    assert resp.get_json()["id"] == comp_id
+
+    resp = client.get("/api/cours", headers=headers)
+    assert resp.status_code == 200
+    assert any(c["id"] == cours_id for c in resp.get_json())
+
+    resp = client.get(f"/api/cours/{cours_id}", headers=headers)
+    assert resp.status_code == 200
+    assert resp.get_json()["code"] == "C101"
+
+    resp = client.get(f"/api/cours/{cours_id}/plan_cadre", headers=headers)
+    assert resp.status_code == 200
+    assert resp.get_json()["id"] == plan_cadre_id
+
+    resp = client.get(f"/api/cours/{cours_id}/plans_de_cours", headers=headers)
+    assert resp.status_code == 200
+    assert resp.get_json()[0]["id"] == plan_de_cours_id
+
+    resp = client.get(f"/api/plan_cadre/{plan_cadre_id}/section/place_intro", headers=headers)
+    assert resp.status_code == 200
+    assert "place_intro" in resp.get_json()
+
+
+def test_api_token_lifecycle(app, client, monkeypatch):
+    # allow login without real recaptcha
+    from src.app.routes import routes as routes_module
+
+    monkeypatch.setattr(routes_module, "verify_recaptcha", lambda token: True)
+
+    user_id, _ = create_user(app, token=None)
+
+    # login to obtain session
+    client.post(
+        "/login",
+        data={"username": "tester", "password": "password", "recaptcha_token": "dummy"},
+        follow_redirects=True,
+    )
+
+    # no token yet
+    resp = client.get("/api/token")
+    assert resp.status_code == 201
+    token = resp.get_json()["token"]
+
+    headers = {"X-API-Token": token}
+    assert client.get("/api/programmes", headers=headers).status_code == 200
+
+    # create an immediately expired token
+    resp = client.post("/api/token?ttl=0")
+    expired_token = resp.get_json()["token"]
+    headers = {"X-API-Token": expired_token}
+    assert client.get("/api/programmes", headers=headers).status_code == 401
+
+
+def test_developer_page_token_generation(app, client, monkeypatch):
+    from src.app.routes import routes as routes_module
+    monkeypatch.setattr(routes_module, "verify_recaptcha", lambda token: True)
+
+    user_id, _ = create_user(app, token=None)
+
+    client.post(
+        "/login",
+        data={"username": "tester", "password": "password", "recaptcha_token": "dummy"},
+        follow_redirects=True,
+    )
+
+    resp = client.get("/settings/developer")
+    assert resp.status_code == 200
+
+    resp = client.post("/settings/developer", data={"ttl": "1"}, follow_redirects=True)
+    assert resp.status_code == 200
+
+    with app.app_context():
+        user = db.session.get(User, user_id)
+        assert user.api_token is not None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -23,18 +23,14 @@ def test_version_endpoint(client):
     assert 'version' in data, "Response JSON should contain a 'version' key."
     assert data['version'] == __version__, f"Version should be {__version__}."
 
-def test_public_endpoint_redirection(client):
+def test_root_shows_login_page(client):
     """
-    Checks that an attempt to access a protected endpoint redirects to the login page.
-    (Here we assume that the '/' route is protected.)
+    The root path should be publicly accessible and display the login form
+    when no user is authenticated.
     """
     response = client.get('/')
-    # In testing mode, if the user is not authenticated a redirection should occur.
-    assert response.status_code in (301, 302), "A redirection is expected for protected endpoints."
-
-    location = response.headers.get("Location")
-    assert location is not None, "A 'Location' header must be present upon redirection."
-    assert "login" in location, "The redirection should point to the login page."
+    assert response.status_code == 200, "Root should return 200 for unauthenticated users."
+    assert b"Se connecter" in response.data, "Login page should be rendered at root."
 
 def test_static_files_access(client):
     """

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 from src.app import db
 from src.app.models import OAuthToken
-from src.mcp_server.server import DBTokenVerifier, init_app as init_mcp_app
+from src.mcp_server.server import DBTokenVerifier, init_app as init_mcp_app, mcp
 
 
 def test_db_token_verifier(app):
@@ -16,3 +16,7 @@ def test_db_token_verifier(app):
         access = asyncio.run(verifier.verify_token("tok"))
         assert access is not None and access.client_id == "cli"
         assert asyncio.run(verifier.verify_token("bad")) is None
+
+
+def test_mcp_server_uses_oauth_verifier():
+    assert isinstance(mcp.auth, DBTokenVerifier)

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -1,0 +1,18 @@
+import asyncio
+from datetime import datetime, timedelta
+
+from src.app import db
+from src.app.models import OAuthToken
+from src.mcp_server.server import DBTokenVerifier, init_app as init_mcp_app
+
+
+def test_db_token_verifier(app):
+    with app.app_context():
+        token = OAuthToken(token="tok", client_id="cli", expires_at=datetime.utcnow() + timedelta(hours=1))
+        db.session.add(token)
+        db.session.commit()
+        init_mcp_app(app)
+        verifier = DBTokenVerifier()
+        access = asyncio.run(verifier.verify_token("tok"))
+        assert access is not None and access.client_id == "cli"
+        assert asyncio.run(verifier.verify_token("bad")) is None

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,68 @@
+from src.app import db
+from src.app.models import (
+    Programme,
+    Department,
+    Cours,
+    PlanCadre,
+    PlanDeCours,
+    Competence,
+)
+
+from src.mcp_server.server import (
+    programmes,
+    programme_courses,
+    programme_competences,
+    competence_details,
+    cours,
+    cours_details,
+    cours_plan_cadre,
+    cours_plans_de_cours,
+    plan_cadre_section,
+)
+
+
+def setup_data(app):
+    with app.app_context():
+        dept = Department(nom="Dep")
+        db.session.add(dept)
+        db.session.commit()
+
+        programme = Programme(nom="Prog", department_id=dept.id)
+        db.session.add(programme)
+        db.session.commit()
+
+        cours_obj = Cours(
+            code="C101",
+            nom="Course",
+            heures_theorie=0,
+            heures_laboratoire=0,
+            heures_travail_maison=0,
+        )
+        db.session.add(cours_obj)
+        db.session.commit()
+        cours_obj.programmes.append(programme)
+        db.session.commit()
+
+        plan_cadre = PlanCadre(cours_id=cours_obj.id)
+        db.session.add(plan_cadre)
+        plan_de_cours = PlanDeCours(cours_id=cours_obj.id, session="A25")
+        db.session.add(plan_de_cours)
+
+        comp = Competence(programme_id=programme.id, code="COMP1", nom="Comp 1")
+        db.session.add(comp)
+        db.session.commit()
+
+        return programme.id, cours_obj.id, plan_cadre.id, plan_de_cours.id, comp.id
+def test_mcp_resources(app):
+    prog_id, cours_id, plan_cadre_id, plan_de_cours_id, comp_id = setup_data(app)
+
+    with app.app_context():
+        assert any(p["id"] == prog_id for p in programmes())
+        assert programme_courses(prog_id)[0]["id"] == cours_id
+        assert programme_competences(prog_id)[0]["id"] == comp_id
+        assert competence_details(comp_id)["id"] == comp_id
+        assert any(c["id"] == cours_id for c in cours())
+        assert cours_details(cours_id)["code"] == "C101"
+        assert cours_plan_cadre(cours_id)["id"] == plan_cadre_id
+        assert cours_plans_de_cours(cours_id)[0]["id"] == plan_de_cours_id
+        assert "place_intro" in plan_cadre_section(plan_cadre_id, "place_intro")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -18,6 +18,8 @@ from src.mcp_server.server import (
     cours_plan_cadre,
     cours_plans_de_cours,
     plan_cadre_section,
+    search,
+    fetch,
 )
 
 
@@ -66,3 +68,12 @@ def test_mcp_resources(app):
         assert cours_plan_cadre(cours_id)["id"] == plan_cadre_id
         assert cours_plans_de_cours(cours_id)[0]["id"] == plan_de_cours_id
         assert "place_intro" in plan_cadre_section(plan_cadre_id, "place_intro")
+
+
+def test_search_and_fetch(app):
+    prog_id, cours_id, _, _, _ = setup_data(app)
+    with app.app_context():
+        results = search("Prog")
+        assert any(r["id"] == f"programme:{prog_id}" for r in results)
+        item = fetch(f"programme:{prog_id}")
+        assert item["title"] == "Prog"

--- a/tests/test_oauth_flow.py
+++ b/tests/test_oauth_flow.py
@@ -1,5 +1,5 @@
 from src.app import db
-from src.app.models import Programme, Department
+from src.app.models import Programme, Department, OAuthClient, User
 
 
 def setup_data(app):
@@ -39,3 +39,70 @@ def test_oauth_registration_and_access(app, client):
     data = meta.get_json()
     assert data['token_endpoint'].endswith('/token')
     assert data['registration_endpoint'].endswith('/register')
+
+
+def test_authorization_code_flow(app, client):
+    prog_id = setup_data(app)
+
+    with app.app_context():
+        client_obj = OAuthClient(
+            client_id='cid',
+            client_secret='secret',
+            name='test',
+            redirect_uri='https://example.com/cb',
+        )
+        db.session.add(client_obj)
+        user = User(username='u', password='p')
+        db.session.add(user)
+        db.session.commit()
+        user_id = user.id
+
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(user_id)
+        sess['_fresh'] = True
+
+    import hashlib, base64
+    code_verifier = 'verifier123'
+    code_challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(code_verifier.encode()).digest()
+    ).rstrip(b'=').decode()
+
+    resp = client.get(
+        '/authorize',
+        query_string={
+            'response_type': 'code',
+            'client_id': 'cid',
+            'redirect_uri': 'https://example.com/cb',
+            'code_challenge': code_challenge,
+        },
+    )
+    assert resp.status_code == 200
+
+    resp = client.post(
+        '/authorize?client_id=cid&redirect_uri=https://example.com/cb',
+        data={'confirm': 'yes', 'code_challenge': code_challenge},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    from urllib.parse import urlparse, parse_qs
+
+    parsed = urlparse(resp.headers['Location'])
+    code = parse_qs(parsed.query)['code'][0]
+
+    token_resp = client.post(
+        '/token',
+        json={
+            'grant_type': 'authorization_code',
+            'code': code,
+            'code_verifier': code_verifier,
+            'client_id': 'cid',
+            'client_secret': 'secret',
+        },
+    )
+    assert token_resp.status_code == 200
+    token = token_resp.get_json()['access_token']
+
+    headers = {'Authorization': f'Bearer {token}'}
+    resp = client.get('/api/programmes', headers=headers)
+    assert resp.status_code == 200
+    assert any(p['id'] == prog_id for p in resp.get_json())

--- a/tests/test_oauth_flow.py
+++ b/tests/test_oauth_flow.py
@@ -1,0 +1,35 @@
+from src.app import db
+from src.app.models import Programme, Department
+
+
+def setup_data(app):
+    with app.app_context():
+        dept = Department(nom="Dep")
+        db.session.add(dept)
+        db.session.commit()
+        programme = Programme(nom="Prog", department_id=dept.id)
+        db.session.add(programme)
+        db.session.commit()
+        return programme.id
+
+
+def test_oauth_registration_and_access(app, client):
+    prog_id = setup_data(app)
+
+    resp = client.post('/oauth/register', json={'name': 'client'})
+    assert resp.status_code == 201
+    creds = resp.get_json()
+    client_id = creds['client_id']
+    client_secret = creds['client_secret']
+
+    resp = client.post('/oauth/token', json={'client_id': client_id, 'client_secret': client_secret, 'ttl': 3600})
+    assert resp.status_code == 200
+    token = resp.get_json()['access_token']
+
+    headers = {'Authorization': f'Bearer {token}'}
+    resp = client.get('/api/programmes', headers=headers)
+    assert resp.status_code == 200
+    assert any(p['id'] == prog_id for p in resp.get_json())
+
+    bad = {'Authorization': 'Bearer wrong'}
+    assert client.get('/api/programmes', headers=bad).status_code == 401

--- a/tests/test_oauth_flow.py
+++ b/tests/test_oauth_flow.py
@@ -16,13 +16,13 @@ def setup_data(app):
 def test_oauth_registration_and_access(app, client):
     prog_id = setup_data(app)
 
-    resp = client.post('/oauth/register', json={'name': 'client'})
+    resp = client.post('/register', json={'name': 'client'})
     assert resp.status_code == 201
     creds = resp.get_json()
     client_id = creds['client_id']
     client_secret = creds['client_secret']
 
-    resp = client.post('/oauth/token', json={'client_id': client_id, 'client_secret': client_secret, 'ttl': 3600})
+    resp = client.post('/token', json={'client_id': client_id, 'client_secret': client_secret, 'ttl': 3600})
     assert resp.status_code == 200
     token = resp.get_json()['access_token']
 
@@ -33,3 +33,9 @@ def test_oauth_registration_and_access(app, client):
 
     bad = {'Authorization': 'Bearer wrong'}
     assert client.get('/api/programmes', headers=bad).status_code == 401
+
+    meta = client.get('/.well-known/oauth-authorization-server')
+    assert meta.status_code == 200
+    data = meta.get_json()
+    assert data['token_endpoint'].endswith('/token')
+    assert data['registration_endpoint'].endswith('/register')


### PR DESCRIPTION
## Summary
- expand API help page with curl examples showing how to call endpoints and generate plans
- add a FastMCP server exposing programme, course, and plan resources

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ed8929ec883229550c2fccd83d2a9