### PR TITLE
Respecte X-Forwarded-Prefix pour OAuth

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -119,7 +119,8 @@ def create_app(testing=False):
         static_folder=os.path.join(base_path, "static")
     )
 
-    app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
+    # Respect reverse proxy headers for scheme, host and path prefix
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1, x_prefix=1)
 
     # Configuration based on environment
     if testing:

--- a/tests/test_oauth_flow.py
+++ b/tests/test_oauth_flow.py
@@ -106,3 +106,16 @@ def test_authorization_code_flow(app, client):
     resp = client.get('/api/programmes', headers=headers)
     assert resp.status_code == 200
     assert any(p['id'] == prog_id for p in resp.get_json())
+
+
+def test_oauth_metadata_respects_prefix(client):
+    """Issuer and endpoints include the forwarded prefix."""
+    resp = client.get(
+        '/.well-known/oauth-authorization-server',
+        headers={'X-Forwarded-Prefix': '/mcp'},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['issuer'].endswith('/mcp')
+    assert '/mcp' in data['token_endpoint']
+    assert '/mcp' in data['registration_endpoint']


### PR DESCRIPTION
## Summary
- handle reverse proxy prefix in ProxyFix to fix OAuth redirection
- test that OAuth metadata uses forwarded prefix

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f235433248322ad154defef4c8a98