### PR TITLE
Rend la page logigramme de compétences mobile friendly

### DIFF
--- a/src/app/templates/programme/competence_logigramme.html
+++ b/src/app/templates/programme/competence_logigramme.html
@@ -7,11 +7,11 @@
 
 {% block programmes_specific %}
 <div class="container-fluid mt-3">
-  <div class="d-flex flex-wrap align-items-center justify-content-between mb-3 gap-2">
-    <div class="d-flex align-items-center gap-2">
+  <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between mb-3 gap-2">
+    <div class="d-flex align-items-center gap-2 mb-2 mb-md-0">
       <h4 class="mb-0">Logigramme des compétences — {{ programme.nom }}</h4>
     </div>
-    <div class="d-flex align-items-center gap-2">
+    <div class="d-flex flex-wrap align-items-center gap-2">
       <!-- Mode timeline retiré pour le moment -->
       <div class="btn-group btn-group-sm" role="group" aria-label="Filtrer les liens">
         <input type="checkbox" class="btn-check" id="toggleDeveloppee" checked>
@@ -23,7 +23,7 @@
         <input type="checkbox" class="btn-check" id="toggleReinvesti" checked>
         <label class="btn btn-outline-secondary" for="toggleReinvesti">Réinvesti</label>
       </div>
-      <div class="input-group input-group-sm" style="width: 280px;">
+      <div class="input-group input-group-sm flex-grow-1" style="min-width: 180px; max-width: 280px;">
         <span class="input-group-text"><i class="bi bi-search"></i></span>
         <input id="searchBox" type="search" class="form-control" placeholder="Rechercher compétence ou cours">
       </div>

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -51,6 +51,7 @@ from src.app.models import (
     Department,
 )
 from src.app.routes.oauth import TOKEN_RESOURCES
+from src.extensions import db
 
 # ---------------------------------------------------------------------------
 # Flask application binding

--- a/src/static/css/competence_logigramme.css
+++ b/src/static/css/competence_logigramme.css
@@ -27,7 +27,7 @@
 }
 
 /* Legend */
-.legend { color: #555; display: flex; gap: 16px; align-items: center; }
+.legend { color: #555; display: flex; gap: 16px; align-items: center; flex-wrap: wrap; }
 .legend-item { display: inline-flex; align-items: center; gap: 6px; }
 .legend-dot { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
 .legend-comp { background: #6c63ff; }


### PR DESCRIPTION
## Résumé
- Réorganise la barre d'outils du logigramme pour s'adapter aux petits écrans et rendre le champ de recherche responsive
- Autorise l'enroulement de la légende du logigramme sur mobile
- Corrige un import manquant du module `db` dans le serveur MCP

## Test
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68abc5aef6cc8322950f8e353bdf2354