### PR TITLE
Augmente la concurrence du worker Celery

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ WorkingDirectory=/home/'your_user_name'
 Environment="PATH=/home/'your_user_name'/edxo/venv/bin"
 Environment="PYTHONPATH=/home/'your_user_name'/edxo/src"
 Environment="CELERY_WORKER=1"
-ExecStart=/home/'your_user_name'/edxo/venv/bin/celery -A celery_app.celery worker --loglevel=info --hostname=worker2@%h
+ExecStart=/home/'your_user_name'/edxo/venv/bin/celery -A celery_app.celery worker --loglevel=info --concurrency=4 --hostname=worker2@%h
 Restart=always
 RestartSec=10
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     # No host port mapping needed; used only on internal network
   celery:
     build: .
-    command: celery -A src.celery_app:celery worker --loglevel=info --hostname=worker2@%h
+    command: celery -A src.celery_app:celery worker --loglevel=info --concurrency=4 --hostname=worker2@%h
     env_file:
       - .env
     environment:


### PR DESCRIPTION
## Summary
- Augmente la commande du worker Celery pour exécuter quatre processus en parallèle
- Documente la nouvelle option de concurrence dans la configuration systemd

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae4e3d1c50832286bc5797dd54619b