### PR TITLE
Active streaming et résumé de raisonnement pour logigramme

### DIFF
--- a/src/app/tasks/generation_logigramme.py
+++ b/src/app/tasks/generation_logigramme.py
@@ -104,7 +104,9 @@ def generate_programme_logigramme_task(self, programme_id: int, user_id: int, fo
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt}
             ],
-            reasoning={'effort': reasoning_effort},
+            # Explicitly request streaming and a reasoning summary from OpenAI.
+            stream=True,
+            reasoning={"effort": reasoning_effort, "summary": "auto"},
             metadata={'feature': 'generate_programme_logigramme', 'programme_id': str(programme.id)},
         )
 


### PR DESCRIPTION
## Summary
- Demande explicitement le streaming et le résumé de raisonnement lors de la génération du logigramme

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae527dbd388322a5982ddfb0fb9f28