### PR TITLE
Ajout d'un modal avant l'amélioration du plan de cours

### DIFF
--- a/src/app/templates/view_plan_de_cours.html
+++ b/src/app/templates/view_plan_de_cours.html
@@ -901,26 +901,23 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     } catch(_) {}
 
-    // Bouton Améliorer: démarrer la tâche globale via modal simplifié
+    // Bouton Améliorer: ouvrir le Quick Modal pour saisir l'info complémentaire
     try {
       const btnImprove = document.getElementById('openImprovePdcBtn');
-      if (btnImprove && window.EDxoTasks && window.EDxoTasks.startCeleryTask) {
-        btnImprove.addEventListener('click', async (e) => {
+      if (btnImprove && window.EDxoTasks && window.EDxoTasks.openQuickTask) {
+        btnImprove.addEventListener('click', (e) => {
           e.preventDefault();
-          const csrf = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-          const params = new URLSearchParams();
-          params.append('cours_id', "{{ cours.id }}");
-          params.append('session', "{{ plan_de_cours.session }}");
-          params.append('improve_only', 'true');
-          await window.EDxoTasks.startCeleryTask("{{ url_for('plan_de_cours.generate_all_start') }}", {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRFToken': csrf, 'X-CSRF-Token': csrf },
-            body: params.toString(),
-            credentials: 'same-origin'
-          }, {
+          window.EDxoTasks.openQuickTask({
+            url: "{{ url_for('plan_de_cours.generate_all_start') }}",
             title: 'Améliorer le plan de cours',
             startMessage: 'Amélioration en cours…',
-            openModal: true
+            basePayload: { additional_info: '' },
+            fixedPayload: {
+              cours_id: {{ cours.id }},
+              session: "{{ plan_de_cours.session }}",
+              improve_only: true,
+              stream: true
+            }
           });
         });
       }

--- a/src/static/js/task_orchestrator.js
+++ b/src/static/js/task_orchestrator.js
@@ -53,6 +53,7 @@
     label.textContent = opts.title || 'Démarrer';
 
     const fields = Object.assign({}, opts.basePayload || {});
+    const fixedPayload = Object.assign({}, opts.fixedPayload || {});
     if (!('additional_info' in fields)) fields.additional_info = '';
 
     const fieldLabels = Object.assign({
@@ -103,7 +104,8 @@
           payload[key] = v === '' ? 0 : Number(v);
         }
       });
-      const fetchOpts = { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) };
+      const fullPayload = Object.assign({}, fixedPayload, payload);
+      const fetchOpts = { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(fullPayload) };
       try {
         const csrf = getCsrfToken();
         if (csrf) { fetchOpts.headers['X-CSRFToken'] = csrf; fetchOpts.headers['X-CSRF-Token'] = csrf; }


### PR DESCRIPTION
## Summary
- Affiche un modal "Quick Task" avant de lancer l'amélioration d'un plan de cours
- Permet de fournir des informations additionnelles via le modal
- Orchestrateur JS supporte désormais un `fixedPayload` pour ajouter des champs cachés

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae58bf48e88322bbbe21a4cec2496b