### PR TITLE
Simplifie génération plan de cours

### DIFF
--- a/src/app/templates/view_plan_de_cours.html
+++ b/src/app/templates/view_plan_de_cours.html
@@ -895,7 +895,8 @@ document.addEventListener('DOMContentLoaded', function() {
             url: "/api/plan_de_cours/{{ plan_de_cours.id }}/generate",
             title: 'Générer le plan de cours',
             startMessage: 'Génération en cours…',
-            basePayload: { stream: true }
+            fieldLabels: { additional_info: 'Informations complémentaires' },
+            fixedPayload: { stream: true }
           });
         });
       }

--- a/src/static/js/task_orchestrator.js
+++ b/src/static/js/task_orchestrator.js
@@ -54,12 +54,13 @@
 
     const fields = Object.assign({}, opts.basePayload || {});
     if (!('additional_info' in fields)) fields.additional_info = '';
+    const fixedPayload = Object.assign({}, opts.fixedPayload || {});
 
     const fieldLabels = Object.assign({
       nb_sessions: 'Nombre de sessions',
       total_hours: "Total d'heures",
       total_units: "Total d'unités",
-      additional_info: 'Informations additionnelles'
+      additional_info: 'Informations complémentaires'
     }, opts.fieldLabels || {});
 
     body.innerHTML = '';
@@ -92,7 +93,7 @@
     const newBtn = btn.cloneNode(true);
     btn.parentNode.replaceChild(newBtn, btn);
     newBtn.addEventListener('click', async () => {
-      const payload = {};
+      const payload = { ...fixedPayload };
       Object.keys(fields).forEach(key => {
         const el = body.querySelector(`#task-quick-${key}`);
         if (!el) return;


### PR DESCRIPTION
## Summary
- Gère un payload fixe dans le modal rapide et renomme le champ en "Informations complémentaires"
- Envoie la génération du plan de cours avec `stream: true` sans exposer de champ supplémentaire

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae58abed7c8322bacefd99c8ad8c03