### PR TITLE
Ensure reasoning summary displayed in import preview status

### DIFF
--- a/src/app/tasks/import_plan_cadre.py
+++ b/src/app/tasks/import_plan_cadre.py
@@ -597,7 +597,13 @@ def import_plan_cadre_preview_task(self, plan_cadre_id: int, doc_text: str, ai_m
                                         if rs_delta:
                                             reasoning_summary_text += rs_delta
                                             try:
-                                                self.update_state(state='PROGRESS', meta={ 'reasoning_summary': reasoning_summary_text })
+                                                self.update_state(
+                                                    state='PROGRESS',
+                                                    meta={
+                                                        'message': 'Résumé du raisonnement',
+                                                        'reasoning_summary': reasoning_summary_text
+                                                    }
+                                                )
                                             except Exception:
                                                 pass
                                     except Exception:
@@ -611,7 +617,10 @@ def import_plan_cadre_preview_task(self, plan_cadre_id: int, doc_text: str, ai_m
                                 reasoning_summary_text = _extract_reasoning_summary_from_response(final_response)
                                 if reasoning_summary_text:
                                     try:
-                                        self.update_state(state='PROGRESS', meta={'reasoning_summary': reasoning_summary_text})
+                                        self.update_state(
+                                            state='PROGRESS',
+                                            meta={'message': 'Résumé du raisonnement', 'reasoning_summary': reasoning_summary_text}
+                                        )
                                     except Exception:
                                         pass
                     except Exception:
@@ -620,7 +629,10 @@ def import_plan_cadre_preview_task(self, plan_cadre_id: int, doc_text: str, ai_m
                         reasoning_summary_text = _extract_reasoning_summary_from_response(final_response)
                         if reasoning_summary_text:
                             try:
-                                self.update_state(state='PROGRESS', meta={'reasoning_summary': reasoning_summary_text})
+                                self.update_state(
+                                    state='PROGRESS',
+                                    meta={'message': 'Résumé du raisonnement', 'reasoning_summary': reasoning_summary_text}
+                                )
                             except Exception:
                                 pass
 
@@ -692,7 +704,10 @@ def import_plan_cadre_preview_task(self, plan_cadre_id: int, doc_text: str, ai_m
                 reasoning_summary_text = _extract_reasoning_summary_from_response(response)
                 if reasoning_summary_text:
                     try:
-                        self.update_state(state='PROGRESS', meta={'reasoning_summary': reasoning_summary_text})
+                        self.update_state(
+                            state='PROGRESS',
+                            meta={'message': 'Résumé du raisonnement', 'reasoning_summary': reasoning_summary_text}
+                        )
                     except Exception:
                         pass
 

--- a/tests/tasks/test_import_plan_cadre_reasoning_summary.py
+++ b/tests/tasks/test_import_plan_cadre_reasoning_summary.py
@@ -1,0 +1,6 @@
+import inspect
+
+def test_import_plan_cadre_reasoning_summary_contains_message():
+    from src.app.tasks import import_plan_cadre
+    source = inspect.getsource(import_plan_cadre.import_plan_cadre_preview_task)
+    assert "'message': 'Résumé du raisonnement'" in source


### PR DESCRIPTION
## Summary
- add missing message when streaming reasoning summary in `import_plan_cadre_preview_task`
- add regression test to ensure reasoning summary message is present

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afa9243cc48322b84cffc8cebce1bb