### PR TITLE
Fix missing required fields in plan de cours schema

### DIFF
--- a/src/app/tasks/import_plan_de_cours.py
+++ b/src/app/tasks/import_plan_de_cours.py
@@ -79,34 +79,74 @@ PLAN_DE_COURS_JSON_SCHEMA = {
         "evaluation_formative_apprentissages": {"type": ["string", "null"]},
         "evaluation_expression_francais": {"type": ["string", "null"]},
         "materiel": {"type": ["string", "null"]},
-        "calendriers": {"type": "array", "items": {"type": "object", "properties": {
-            "semaine": {"type": ["integer", "null"]},
-            "sujet": {"type": ["string", "null"]},
-            "activites": {"type": ["string", "null"]},
-            "travaux_hors_classe": {"type": ["string", "null"]},
-            "evaluations": {"type": ["string", "null"]}
-        }, "additionalProperties": False}},
+        "calendriers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "semaine": {"type": ["integer", "null"]},
+                    "sujet": {"type": ["string", "null"]},
+                    "activites": {"type": ["string", "null"]},
+                    "travaux_hors_classe": {"type": ["string", "null"]},
+                    "evaluations": {"type": ["string", "null"]}
+                },
+                "required": ["semaine", "sujet", "activites", "travaux_hors_classe", "evaluations"],
+                "additionalProperties": False,
+            },
+        },
         "nom_enseignant": {"type": ["string", "null"]},
         "telephone_enseignant": {"type": ["string", "null"]},
         "courriel_enseignant": {"type": ["string", "null"]},
         "bureau_enseignant": {"type": ["string", "null"]},
-        "disponibilites": {"type": "array", "items": {"type": "object", "properties": {
-            "jour_semaine": {"type": ["string", "null"]},
-            "plage_horaire": {"type": ["string", "null"]},
-            "lieu": {"type": ["string", "null"]}
-        }, "additionalProperties": False}},
-        "mediagraphies": {"type": "array", "items": {"type": "object", "properties": {
-            "reference_bibliographique": {"type": ["string", "null"]}
-        }, "additionalProperties": False}},
-        "evaluations": {"type": "array", "items": {"type": "object", "properties": {
-            "titre_evaluation": {"type": ["string", "null"]},
-            "description": {"type": ["string", "null"]},
-            "semaine": {"type": ["integer", "null"]},
-            "capacites": {"type": "array", "items": {"type": "object", "properties": {
-                "capacite": {"type": ["string", "null"]},
-                "ponderation": {"type": ["string", "null"]}
-            }, "additionalProperties": False}}
-        }, "additionalProperties": False}}
+        "disponibilites": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "jour_semaine": {"type": ["string", "null"]},
+                    "plage_horaire": {"type": ["string", "null"]},
+                    "lieu": {"type": ["string", "null"]}
+                },
+                "required": ["jour_semaine", "plage_horaire", "lieu"],
+                "additionalProperties": False,
+            },
+        },
+        "mediagraphies": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "reference_bibliographique": {"type": ["string", "null"]}
+                },
+                "required": ["reference_bibliographique"],
+                "additionalProperties": False,
+            },
+        },
+        "evaluations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "titre_evaluation": {"type": ["string", "null"]},
+                    "description": {"type": ["string", "null"]},
+                    "semaine": {"type": ["integer", "null"]},
+                    "capacites": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "capacite": {"type": ["string", "null"]},
+                                "ponderation": {"type": ["string", "null"]},
+                            },
+                            "required": ["capacite", "ponderation"],
+                            "additionalProperties": False,
+                        },
+                    },
+                },
+                "required": ["titre_evaluation", "description", "semaine", "capacites"],
+                "additionalProperties": False,
+            },
+        },
     },
     "additionalProperties": False
 }

--- a/tests/tasks/test_import_plan_de_cours_schema.py
+++ b/tests/tasks/test_import_plan_de_cours_schema.py
@@ -76,3 +76,10 @@ def test_schema_has_no_defs(app):
         assert schema
         assert '$defs' not in schema
         assert schema.get('additionalProperties') is False
+        cal_item = schema['properties']['calendriers']['items']
+        assert set(cal_item['required']) == set(cal_item['properties'].keys())
+        for prop in ['disponibilites', 'mediagraphies', 'evaluations']:
+            item = schema['properties'][prop]['items']
+            assert set(item['required']) == set(item['properties'].keys())
+        cap_item = schema['properties']['evaluations']['items']['properties']['capacites']['items']
+        assert set(cap_item['required']) == set(cap_item['properties'].keys())


### PR DESCRIPTION
## Summary
- enforce required fields for nested plan de cours JSON schema objects
- add tests verifying all schema items list required properties

## Testing
- `pytest -q`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0dcac99208322bad33d8676811c4f