### PR TITLE
Ensure plan_de_cours schema lists all required properties

### DIFF
--- a/src/app/tasks/import_plan_de_cours.py
+++ b/src/app/tasks/import_plan_de_cours.py
@@ -148,6 +148,23 @@ PLAN_DE_COURS_JSON_SCHEMA = {
             },
         },
     },
+    "required": [
+        "presentation_du_cours",
+        "objectif_terminal_du_cours",
+        "organisation_et_methodes",
+        "accomodement",
+        "evaluation_formative_apprentissages",
+        "evaluation_expression_francais",
+        "materiel",
+        "calendriers",
+        "nom_enseignant",
+        "telephone_enseignant",
+        "courriel_enseignant",
+        "bureau_enseignant",
+        "disponibilites",
+        "mediagraphies",
+        "evaluations",
+    ],
     "additionalProperties": False
 }
 

--- a/tests/tasks/test_import_plan_de_cours_schema.py
+++ b/tests/tasks/test_import_plan_de_cours_schema.py
@@ -24,6 +24,10 @@ class FakeResponses:
                 "evaluation_expression_francais": "",
                 "materiel": "",
                 "calendriers": [],
+                "nom_enseignant": "",
+                "telephone_enseignant": "",
+                "courriel_enseignant": "",
+                "bureau_enseignant": "",
                 "disponibilites": [],
                 "mediagraphies": [],
                 "evaluations": [],
@@ -76,6 +80,7 @@ def test_schema_has_no_defs(app):
         assert schema
         assert '$defs' not in schema
         assert schema.get('additionalProperties') is False
+        assert set(schema['required']) == set(schema['properties'].keys())
         cal_item = schema['properties']['calendriers']['items']
         assert set(cal_item['required']) == set(cal_item['properties'].keys())
         for prop in ['disponibilites', 'mediagraphies', 'evaluations']:


### PR DESCRIPTION
## Summary
- enforce `required` array in PLAN_DE_COURS_JSON_SCHEMA to include every property
- test schema generation to assert all root fields are required

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0e796d6e4832296614a74a1cb0e4e