### PR TITLE
Fix JSON parsing for course plan import

### DIFF
--- a/src/app/tasks/import_plan_de_cours.py
+++ b/src/app/tasks/import_plan_de_cours.py
@@ -284,10 +284,21 @@ def _resolve_capacity_id(name: Optional[str], plan_cadre) -> Optional[int]:
 def _extract_first_parsed(response):
     try:
         outputs = getattr(response, 'output', None) or []
+        if isinstance(outputs, dict):
+            outputs = [outputs]
         for item in outputs:
-            contents = getattr(item, 'content', None) or []
+            contents = []
+            if isinstance(item, dict):
+                contents = item.get('content') or []
+            else:
+                contents = getattr(item, 'content', None) or []
+            if isinstance(contents, dict):
+                contents = [contents]
             for c in contents:
-                parsed = getattr(c, 'parsed', None)
+                if isinstance(c, dict):
+                    parsed = c.get('parsed')
+                else:
+                    parsed = getattr(c, 'parsed', None)
                 if parsed is not None:
                     return parsed
     except Exception:

--- a/tests/tasks/test_import_plan_de_cours_dict_output.py
+++ b/tests/tasks/test_import_plan_de_cours_dict_output.py
@@ -1,0 +1,74 @@
+from src.app.tasks.import_plan_de_cours import import_plan_de_cours_task
+from src.app import db
+from src.app.models import Department, Programme, Cours, PlanCadre, PlanDeCours, User, SectionAISettings
+
+class FakeResponses:
+    class _Stream:
+        def __init__(self, recorder):
+            self.recorder = recorder
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            return False
+        def __iter__(self):
+            return iter(())
+        def get_final_response(self):
+            usage = type('U', (), {'input_tokens': 1, 'output_tokens': 1})()
+            parsed = {
+                'presentation_du_cours': '',
+                'objectif_terminal_du_cours': '',
+                'organisation_et_methodes': '',
+                'accomodement': '',
+                'evaluation_formative_apprentissages': '',
+                'evaluation_expression_francais': '',
+                'materiel': '',
+                'calendriers': [],
+                'nom_enseignant': '',
+                'telephone_enseignant': '',
+                'courriel_enseignant': '',
+                'bureau_enseignant': '',
+                'disponibilites': [],
+                'mediagraphies': [],
+                'evaluations': [],
+            }
+            output = [{'content': [{'parsed': parsed}]}]
+            return type('Resp', (), {'usage': usage, 'output': output})()
+    def __init__(self, recorder):
+        self.recorder = recorder
+    def stream(self, **kwargs):
+        self.recorder['text'] = kwargs.get('text')
+        return FakeResponses._Stream(self.recorder)
+
+class FakeFiles:
+    def __init__(self, recorder):
+        self.recorder = recorder
+    def create(self, file=None, purpose=None):  # noqa: ARG002
+        return type('Up', (), {'id': 'file-id'})()
+
+class FakeOpenAI:
+    def __init__(self, api_key=None):  # noqa: ARG002
+        self.calls = {}
+        self.files = FakeFiles(self.calls)
+        self.responses = FakeResponses(self.calls)
+
+
+def test_import_plan_de_cours_task_handles_dict_output(app):
+    with app.app_context():
+        dept = Department(nom='D'); db.session.add(dept); db.session.flush()
+        prog = Programme(nom='P', department_id=dept.id); db.session.add(prog); db.session.flush()
+        cours = Cours(code='C', nom='Cours', heures_theorie=0, heures_laboratoire=0, heures_travail_maison=0)
+        db.session.add(cours); db.session.flush(); cours.programmes.append(prog); db.session.flush()
+        pc = PlanCadre(cours_id=cours.id); db.session.add(pc); db.session.flush()
+        plan = PlanDeCours(cours_id=cours.id, session='A25'); db.session.add(plan); db.session.flush()
+        user = User(username='u', password='x', email='u@example.com', openai_key='sk', credits=10.0)
+        db.session.add(user); db.session.add(SectionAISettings(section='plan_de_cours_import', system_prompt=''))
+        db.session.commit()
+
+        class DummySelf:
+            request = type('R', (), {'id': 'tid'})()
+            def update_state(self, state=None, meta=None):  # noqa: ANN001,ARG002
+                return None
+
+        orig = import_plan_de_cours_task.__wrapped__.__func__
+        result = orig(DummySelf(), plan.id, 'text', 'gpt-5', user.id, None, FakeOpenAI)
+        assert result.get('status') == 'success'


### PR DESCRIPTION
## Summary
- handle dict-like responses when parsing plan import outputs
- add regression test for dict output from OpenAI response

## Testing
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_68b0ec2ba4488322bf552c413667b5b5