### PR TITLE
Gère output_parsed dans extraction

### DIFF
--- a/src/app/tasks/generation_plan_de_cours.py
+++ b/src/app/tasks/generation_plan_de_cours.py
@@ -34,7 +34,23 @@ class BulkPlanDeCoursResponse(BaseModel):
 
 
 def _extract_first_parsed(response):
+    """Retourne le premier objet parsé d'une réponse OpenAI.
+
+    La structure renvoyée par l'API OpenAI a évolué. Certains appels
+    exposent directement une liste ``output_parsed`` tandis que d'autres
+    nécessitent de parcourir ``output -> content -> parsed``. Cette
+    fonction gère les deux cas et renvoie ``None`` si aucune donnée n'est
+    trouvée.
+    """
     try:
+        # Nouveau format : output_parsed disponible directement
+        output_parsed = getattr(response, 'output_parsed', None)
+        if output_parsed:
+            if isinstance(output_parsed, list):
+                return output_parsed[0]
+            return output_parsed
+
+        # Ancien format : parcourir les sorties et contenus
         outputs = getattr(response, 'output', None) or []
         for item in outputs:
             contents = getattr(item, 'content', None) or []

--- a/tests/test_extract_first_parsed.py
+++ b/tests/test_extract_first_parsed.py
@@ -1,0 +1,31 @@
+from src.app.tasks.generation_plan_de_cours import _extract_first_parsed
+
+
+class DummyContent:
+    def __init__(self, parsed=None):
+        self.parsed = parsed
+
+
+class DummyItem:
+    def __init__(self, content=None):
+        self.content = content or []
+
+
+class DummyResponse:
+    def __init__(self, output=None, output_parsed=None):
+        if output is not None:
+            self.output = output
+        if output_parsed is not None:
+            self.output_parsed = output_parsed
+
+
+def test_extract_from_output_parsed():
+    parsed_obj = {"a": 1}
+    response = DummyResponse(output_parsed=[parsed_obj])
+    assert _extract_first_parsed(response) == parsed_obj
+
+
+def test_extract_from_nested_content():
+    parsed_obj = {"b": 2}
+    response = DummyResponse(output=[DummyItem([DummyContent(parsed_obj)])])
+    assert _extract_first_parsed(response) == parsed_obj


### PR DESCRIPTION
## Summary
- Support the new `output_parsed` attribute returned by OpenAI responses
- Exercise `_extract_first_parsed` via unit tests for both legacy and new response formats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0f43e82b08322bf572ed4548d75f3