### PR TITLE
Add admin DOCX to JSON schema conversion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ python-dotenv
 pytz
 redis
 reportlab
+pytest-asyncio
 requests
 starlette
 tiktoken

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -43,6 +43,7 @@ from .routes import courses_management  # noqa: F401
 from .routes import competences_management  # noqa: F401
 from .routes import fil_conducteur_routes  # noqa: F401
 from .routes import settings_departements  # noqa: F401
+from .routes import admin_docx_schema  # noqa: F401
 from .routes.chat import chat
 # Import blueprints
 from .routes.cours import cours_bp
@@ -58,7 +59,6 @@ from .routes.grilles import grille_bp
 from .routes.api import api_bp
 from .routes.oauth import oauth_bp
 from .routes.tasks import tasks_bp
-from ..mcp_server.server import init_app as init_mcp_server
 
 # Import version
 from ..config.version import __version__
@@ -246,6 +246,7 @@ def create_app(testing=False):
     init_change_tracking(db)
 
     # Bind Flask app to MCP server for OAuth verification
+    from ..mcp_server.server import init_app as init_mcp_server
     init_mcp_server(app)
 
     if not testing:

--- a/src/app/forms.py
+++ b/src/app/forms.py
@@ -73,6 +73,22 @@ class FileUploadForm(FlaskForm):
     file = FileField("Importez un fichier PDF", validators=[DataRequired()])
     submit = SubmitField("Envoyer")
 
+
+class DocxToSchemaForm(FlaskForm):
+    file = FileField("Fichier DOCX", validators=[DataRequired()])
+    model = StringField("Modèle", default="gpt-4o-mini", validators=[DataRequired()])
+    reasoning_level = SelectField(
+        "Niveau de raisonnement",
+        choices=[('low', 'Faible'), ('medium', 'Moyen'), ('high', 'Élevé')],
+        default='medium'
+    )
+    verbosity = SelectField(
+        "Verbosité",
+        choices=[('low', 'Faible'), ('medium', 'Moyenne'), ('high', 'Élevée')],
+        default='medium'
+    )
+    submit = SubmitField("Convertir")
+
 class AssociateDevisForm(FlaskForm):
     base_filename = HiddenField(validators=[DataRequired()])
     programme_id = SelectField("Choisir le Programme Cible :", coerce=int, validators=[DataRequired()])

--- a/src/app/routes/admin_docx_schema.py
+++ b/src/app/routes/admin_docx_schema.py
@@ -1,0 +1,44 @@
+import os
+import re
+import time
+from flask import render_template, request, jsonify, current_app
+from flask_login import login_required, current_user
+
+from ..forms import DocxToSchemaForm
+from ..tasks.docx_to_schema import docx_to_json_schema_task
+from .routes import main
+from ...utils.decorator import role_required, ensure_profile_completed
+
+
+@main.route('/docx_to_schema', methods=['GET'])
+@role_required('admin')
+@ensure_profile_completed
+def docx_to_schema_page():
+    form = DocxToSchemaForm()
+    return render_template('docx_to_schema.html', form=form)
+
+
+@main.route('/docx_to_schema/start', methods=['POST'])
+@role_required('admin')
+@ensure_profile_completed
+def docx_to_schema_start():
+    form = DocxToSchemaForm()
+    if 'file' not in request.files:
+        return jsonify({'error': 'Aucun fichier fourni.'}), 400
+    file = request.files['file']
+    if not file or not file.filename.lower().endswith('.docx'):
+        return jsonify({'error': 'Veuillez fournir un fichier .docx.'}), 400
+
+    upload_dir = os.path.join(current_app.config.get('UPLOAD_FOLDER', 'uploads'))
+    os.makedirs(upload_dir, exist_ok=True)
+    safe_name = re.sub(r'[^A-Za-z0-9_.-]+', '_', file.filename)
+    stored_name = f"docx_schema_{int(time.time())}_{safe_name}"
+    stored_path = os.path.join(upload_dir, stored_name)
+    file.save(stored_path)
+
+    model = request.form.get('model', 'gpt-4o-mini')
+    reasoning = request.form.get('reasoning_level', 'medium')
+    verbosity = request.form.get('verbosity', 'medium')
+
+    task = docx_to_json_schema_task.delay(stored_path, model, reasoning, verbosity, current_user.id)
+    return jsonify({'task_id': task.id}), 202

--- a/src/app/tasks/__init__.py
+++ b/src/app/tasks/__init__.py
@@ -7,3 +7,4 @@ from .import_plan_de_cours import import_plan_de_cours_task
 from .import_plan_cadre import import_plan_cadre_preview_task
 from .generation_logigramme import generate_programme_logigramme_task
 from .generation_grille import generate_programme_grille_task
+from .docx_to_schema import docx_to_json_schema_task

--- a/src/app/tasks/docx_to_schema.py
+++ b/src/app/tasks/docx_to_schema.py
@@ -1,0 +1,126 @@
+import os
+import json
+import logging
+import subprocess
+from typing import Optional
+
+from celery import shared_task
+from docx import Document
+from openai import OpenAI
+
+from ..models import User, db
+from .import_plan_cadre import _create_pdf_from_text
+
+logger = logging.getLogger(__name__)
+
+# Schema describing the expected structure of the model's output
+SCHEMA_OF_SCHEMA = {
+    "name": "SchemaProposal",
+    "strict": True,
+    "schema": {
+        "type": "object",
+        "required": ["title", "description", "json_schema", "example"],
+        "properties": {
+            "title": {"type": "string"},
+            "description": {"type": "string"},
+            "json_schema": {"type": "object"},
+            "example": {"type": "object"}
+        }
+    }
+}
+
+def _docx_to_pdf(docx_path: str) -> str:
+    """Convert a DOCX file to PDF using LibreOffice.
+
+    Falls back to a simple text-based PDF if the conversion fails.
+    Returns the path to the generated PDF.
+    """
+    pdf_path = os.path.splitext(docx_path)[0] + ".pdf"
+    outdir = os.path.dirname(docx_path) or "."
+    try:
+        subprocess.run(
+            [
+                "libreoffice",
+                "--headless",
+                "--convert-to",
+                "pdf",
+                "--outdir",
+                outdir,
+                docx_path,
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if not os.path.exists(pdf_path):
+            raise FileNotFoundError("PDF conversion failed")
+    except Exception:
+        try:
+            doc = Document(docx_path)
+            text = "\n".join(p.text for p in doc.paragraphs if p.text.strip())
+        except Exception:
+            text = ""
+        _create_pdf_from_text(text or "Document importé", pdf_path)
+    return pdf_path
+
+@shared_task(bind=True, name="app.tasks.docx_to_schema.convert")
+def docx_to_json_schema_task(self, docx_path: str, model: str, reasoning: str, verbosity: str, user_id: int, openai_cls=OpenAI):
+    """Convert a DOCX file to a JSON Schema using OpenAI's file API with streaming."""
+    task_id = self.request.id
+    logger.info("[%s] Starting DOCX→Schema for %s", task_id, docx_path)
+
+    user: Optional[User]
+    with db.session.no_autoflush:
+        user = db.session.get(User, user_id)
+    if not user or not user.openai_key:
+        return {"status": "error", "message": "Clé OpenAI manquante."}
+
+    pdf_path = _docx_to_pdf(docx_path)
+    client = openai_cls(api_key=user.openai_key)
+    with open(pdf_path, "rb") as fh:
+        uploaded = client.files.create(file=fh, purpose="responses")
+
+    def push(meta):
+        try:
+            self.update_state(state="PROGRESS", meta=meta)
+        except Exception:
+            logger.exception("Failed to update task state")
+
+    with client.responses.stream(
+        model=model,
+        reasoning={"effort": reasoning},
+        verbosity=verbosity,
+        input=[
+            {
+                "role": "system",
+                "content": "Propose un JSON Schema minimal, cohérent et normalisé pour représenter ce document."
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_file", "file_id": uploaded.id}
+                ]
+            }
+        ],
+        response_format={"type": "json_schema", "json_schema": SCHEMA_OF_SCHEMA}
+    ) as stream:
+        for event in stream:
+            etype = getattr(event, "type", "")
+            if etype == "response.output_text.delta":
+                push({"stream_chunk": event.delta})
+            elif etype == "response.reasoning_summary.delta":
+                push({"reasoning_summary": event.delta})
+        final = stream.get_final_response()
+
+    usage = getattr(final, "usage", None)
+    api_usage = {
+        "prompt_tokens": getattr(usage, "input_tokens", 0),
+        "completion_tokens": getattr(usage, "output_tokens", 0),
+        "model": model,
+    }
+    result_text = getattr(final, "output_text", "")
+    try:
+        parsed = json.loads(result_text)
+    except Exception:
+        parsed = result_text
+    return {"status": "success", "result": parsed, "api_usage": api_usage}

--- a/src/app/templates/docx_to_schema.html
+++ b/src/app/templates/docx_to_schema.html
@@ -1,0 +1,148 @@
+{% extends "base.html" %}
+{% block title %}Conversion DOCX en JSON Schema{% endblock %}
+
+{% block content %}
+<h1>Conversion DOCX en JSON Schema</h1>
+<form id="docxSchemaForm" method="POST" enctype="multipart/form-data">
+    {{ form.hidden_tag() }}
+    <div class="mb-3">
+        {{ form.file.label(class_='form-label') }}
+        {{ form.file(class_='form-control') }}
+    </div>
+    <div class="mb-3">
+        {{ form.model.label(class_='form-label') }}
+        {{ form.model(class_='form-control') }}
+    </div>
+    <div class="mb-3">
+        {{ form.reasoning_level.label(class_='form-label') }}
+        {{ form.reasoning_level(class_='form-select') }}
+    </div>
+    <div class="mb-3">
+        {{ form.verbosity.label(class_='form-label') }}
+        {{ form.verbosity(class_='form-select') }}
+    </div>
+    <div>{{ form.submit(class_='btn btn-primary') }}</div>
+</form>
+
+<div id="schemaResultContainer" class="mt-4 d-none">
+    <h2>Schéma généré</h2>
+    <div class="accordion" id="schemaAccordion">
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="schemaHeadingTitle">
+                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#schemaCollapseTitle" aria-expanded="true" aria-controls="schemaCollapseTitle">
+                    Titre
+                </button>
+            </h2>
+            <div id="schemaCollapseTitle" class="accordion-collapse collapse show" aria-labelledby="schemaHeadingTitle" data-bs-parent="#schemaAccordion">
+                <div class="accordion-body" id="schemaResultTitle"></div>
+            </div>
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="schemaHeadingDesc">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#schemaCollapseDesc" aria-expanded="false" aria-controls="schemaCollapseDesc">
+                    Description
+                </button>
+            </h2>
+            <div id="schemaCollapseDesc" class="accordion-collapse collapse" aria-labelledby="schemaHeadingDesc" data-bs-parent="#schemaAccordion">
+                <div class="accordion-body" id="schemaResultDescription"></div>
+            </div>
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="schemaHeadingSchema">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#schemaCollapseSchema" aria-expanded="false" aria-controls="schemaCollapseSchema">
+                    JSON Schema
+                </button>
+            </h2>
+            <div id="schemaCollapseSchema" class="accordion-collapse collapse" aria-labelledby="schemaHeadingSchema" data-bs-parent="#schemaAccordion">
+                <div class="accordion-body">
+                    <div id="schemaResultTree" class="mb-2"></div>
+                    <pre class="mb-0" id="schemaResultJson"></pre>
+                </div>
+            </div>
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="schemaHeadingExample">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#schemaCollapseExample" aria-expanded="false" aria-controls="schemaCollapseExample">
+                    Exemple
+                </button>
+            </h2>
+            <div id="schemaCollapseExample" class="accordion-collapse collapse" aria-labelledby="schemaHeadingExample" data-bs-parent="#schemaAccordion">
+                <div class="accordion-body"><pre class="mb-0" id="schemaResultExample"></pre></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('docxSchemaForm');
+  const container = document.getElementById('schemaResultContainer');
+  const titleEl = document.getElementById('schemaResultTitle');
+  const descEl = document.getElementById('schemaResultDescription');
+  const schemaEl = document.getElementById('schemaResultJson');
+  const schemaTreeEl = document.getElementById('schemaResultTree');
+  const exampleEl = document.getElementById('schemaResultExample');
+
+  function renderJsonTree(schema, parent, name='root') {
+    if (!schema || !parent) return;
+    const details = document.createElement('details');
+    const summary = document.createElement('summary');
+    const type = schema.type || 'any';
+    summary.textContent = `${name} (${type})`;
+    details.appendChild(summary);
+    if (schema.type === 'object' && schema.properties) {
+      for (const [key, val] of Object.entries(schema.properties)) {
+        renderJsonTree(val, details, key);
+      }
+    } else if (schema.type === 'array' && schema.items) {
+      renderJsonTree(schema.items, details, 'items');
+    }
+    parent.appendChild(details);
+  }
+
+  function renderResult(res) {
+    if (!res) return;
+    try { titleEl.textContent = res.title || ''; } catch {}
+    try { descEl.textContent = res.description || ''; } catch {}
+    try {
+      schemaEl.textContent = JSON.stringify(res.json_schema, null, 2);
+      schemaTreeEl.innerHTML = '';
+      renderJsonTree(res.json_schema, schemaTreeEl, 'root');
+    } catch {}
+    try { exampleEl.textContent = JSON.stringify(res.example, null, 2); } catch {}
+    try { container.classList.remove('d-none'); } catch {}
+  }
+  if (!form) return;
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const fd = new FormData(form);
+    const csrf = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+    try {
+      const startUrl = '/docx_to_schema/start';
+      await window.EDxoTasks.startCeleryTask(startUrl, {
+        method: 'POST',
+        body: fd,
+        headers: { 'X-CSRFToken': csrf, 'X-CSRF-Token': csrf },
+        credentials: 'same-origin'
+      }, {
+        title: 'Conversion DOCX',
+        startMessage: 'Conversion en cours…',
+        openModal: true,
+        onDone: (payload, state) => {
+          try {
+            if (state === 'SUCCESS' && payload && payload.result) {
+              renderResult(payload.result);
+            }
+          } catch (err) {
+            console.error('Erreur rendu schéma', err);
+          }
+        }
+      });
+    } catch (err) {
+      console.error('Erreur conversion DOCX', err);
+      try { addNotification('Erreur conversion', 'error'); } catch (_) {}
+    }
+  });
+});
+</script>
+{% endblock %}

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+import pytest
+
+@pytest.fixture(autouse=True)
+def _set_env_defaults():
+    os.environ.setdefault('SECRET_KEY', 'test')
+    os.environ.setdefault('RECAPTCHA_PUBLIC_KEY', 'test')
+    os.environ.setdefault('RECAPTCHA_PRIVATE_KEY', 'test')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,11 @@ import os
 import pytest
 import sys
 
+# Ensure required env vars for app initialization in tests
+os.environ.setdefault('SECRET_KEY', 'test')
+os.environ.setdefault('RECAPTCHA_PUBLIC_KEY', 'test')
+os.environ.setdefault('RECAPTCHA_PRIVATE_KEY', 'test')
+
 # Ensure that the application's source code is importable.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 from src.app import create_app, db

--- a/tests/tasks/test_docx_to_schema_task.py
+++ b/tests/tasks/test_docx_to_schema_task.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from docx import Document
+
+from src.app.models import User, db
+
+
+class DummySelf:
+    def __init__(self):
+        self.request = type('R', (), {'id': 'tid'})()
+        self.updates = []
+
+    def update_state(self, state=None, meta=None):
+        self.updates.append(meta or {})
+
+
+class DummyEvent:
+    def __init__(self, t, delta):
+        self.type = t
+        self.delta = delta
+
+
+class FakeStream:
+    def __init__(self, events):
+        self.events = events
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        return iter(self.events)
+
+    def get_final_response(self):
+        class Usage:
+            input_tokens = 1
+            output_tokens = 2
+        class Resp:
+            output_text = '{}'
+            usage = Usage()
+        return Resp()
+
+
+class FakeResponses:
+    def stream(self, **kwargs):
+        events = [
+            DummyEvent('response.output_text.delta', 'hello'),
+            DummyEvent('response.reasoning_summary.delta', 'because')
+        ]
+        return FakeStream(events)
+
+
+class FakeFiles:
+    def create(self, file=None, purpose=None):  # noqa: ARG002
+        return type('F', (), {'id': 'fid'})()
+
+
+class FakeOpenAI:
+    def __init__(self, api_key=None):  # noqa: ARG002
+        self.files = FakeFiles()
+        self.responses = FakeResponses()
+
+
+def test_docx_to_schema_streaming(app, tmp_path, monkeypatch):
+    docx_path = tmp_path / 'test.docx'
+    doc = Document()
+    doc.add_paragraph('Hello world')
+    doc.save(docx_path)
+
+    def fake_run(cmd, **kwargs):  # noqa: ARG001
+        assert 'libreoffice' in cmd[0]
+        pdf_path = Path(cmd[-1]).with_suffix('.pdf')
+        pdf_path.write_bytes(b'%PDF-1.4')
+        return SimpleNamespace(returncode=0)
+
+    import src.app.tasks.docx_to_schema as module
+    monkeypatch.setattr(module, 'subprocess', SimpleNamespace(run=fake_run))
+
+    with app.app_context():
+        user = User(username='u', password='pw', role='user', openai_key='sk', credits=1.0, is_first_connexion=False)
+        db.session.add(user)
+        db.session.commit()
+        uid = user.id
+
+    dummy = DummySelf()
+    orig = module.docx_to_json_schema_task.__wrapped__.__func__
+    result = orig(dummy, str(docx_path), 'gpt-4o-mini', 'medium', 'medium', uid, FakeOpenAI)
+    assert result['status'] == 'success'
+    assert any('stream_chunk' in u for u in dummy.updates)
+    assert any('reasoning_summary' in u for u in dummy.updates)

--- a/tests/test_docx_to_schema_ui.py
+++ b/tests/test_docx_to_schema_ui.py
@@ -1,0 +1,32 @@
+from werkzeug.security import generate_password_hash
+from src.app.models import User, db
+
+
+def _login(client, user_id):
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(user_id)
+        sess['_fresh'] = True
+
+
+def test_docx_to_schema_page_contains_start_endpoint(app, client):
+    with app.app_context():
+        admin = User(
+            username='admin',
+            password=generate_password_hash('pw'),
+            role='admin',
+            is_first_connexion=False,
+            openai_key='sk'
+        )
+        db.session.add(admin)
+        db.session.commit()
+        admin_id = admin.id
+    _login(client, admin_id)
+    resp = client.get('/docx_to_schema')
+    assert resp.status_code == 200
+    data = resp.data
+    assert b'/docx_to_schema/start' in data
+    assert b'id="schemaResultContainer"' in data
+    assert b'id="schemaAccordion"' in data
+    assert b'id="schemaResultTree"' in data
+    assert b'renderJsonTree' in data
+    assert b'onDone' in data


### PR DESCRIPTION
## Summary
- add `docx_to_json_schema_task` using OpenAI file API and streaming updates
- expose admin page to upload DOCX and launch conversion via task orchestrator
- provide form and tests for DOCX→schema workflow
- convert DOCX to PDF using LibreOffice before schema generation
- render generated JSON schema on admin page via accordion display
- show nested JSON Schema structure with a collapsible tree view

## Testing
- `pip install pytest-asyncio`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b33b0c077c8322b0e83fb8d406bfbb