### PR TITLE
feat: export prompts as markdown

### DIFF
--- a/src/app/routes/settings.py
+++ b/src/app/routes/settings.py
@@ -5,8 +5,6 @@ import io
 from flask import Blueprint, request, render_template, flash, redirect, url_for, jsonify
 from flask import send_from_directory, current_app, send_file
 from flask_login import login_required, current_user
-from flask_wtf.csrf import CSRFProtect
-
 from ..forms import (
     DeletePlanForm,
     UploadForm,
@@ -22,8 +20,6 @@ from ..forms import (
 )
 from .evaluation import AISixLevelGridResponse
 from ...utils.decorator import role_required, roles_required, ensure_profile_completed
-
-csrf = CSRFProtect()
 
 
 # Importez bien sûr db et User depuis vos modèles
@@ -702,7 +698,7 @@ def download_canevas(filename):
     return send_from_directory(upload_folder, filename, as_attachment=True)
 
 
-@settings_bp.route('/prompts/export', methods=['GET'])
+@settings_bp.route('/prompts/export', methods=['POST'])
 @roles_required('admin')
 @login_required
 @ensure_profile_completed

--- a/src/app/templates/parametres.html
+++ b/src/app/templates/parametres.html
@@ -83,9 +83,12 @@
                       <a href="{{ url_for('settings.manage_openai_models') }}" class="list-group-item list-group-item-action {% if request.endpoint == 'settings.manage_openai_models' %}active{% endif %}">
                         <i class="bi bi-cpu me-2"></i>Modèles OpenAI
                       </a>
-                      <a href="{{ url_for('settings.export_prompts') }}" class="list-group-item list-group-item-action">
-                        <i class="bi bi-download me-2"></i>Exporter les prompts
-                      </a>
+                      <form action="{{ url_for('settings.export_prompts') }}" method="post">
+                        {{ csrf_token() }}
+                        <button type="submit" class="list-group-item list-group-item-action border-0 bg-transparent w-100 text-start">
+                          <i class="bi bi-download me-2"></i>Exporter les prompts
+                        </button>
+                      </form>
                     </div>
                   </div>
                 </div>

--- a/src/app/templates/parametres.html
+++ b/src/app/templates/parametres.html
@@ -83,6 +83,9 @@
                       <a href="{{ url_for('settings.manage_openai_models') }}" class="list-group-item list-group-item-action {% if request.endpoint == 'settings.manage_openai_models' %}active{% endif %}">
                         <i class="bi bi-cpu me-2"></i>Modèles OpenAI
                       </a>
+                      <a href="{{ url_for('settings.export_prompts') }}" class="list-group-item list-group-item-action">
+                        <i class="bi bi-download me-2"></i>Exporter les prompts
+                      </a>
                     </div>
                   </div>
                 </div>

--- a/tests/test_prompts_export_route.py
+++ b/tests/test_prompts_export_route.py
@@ -1,0 +1,51 @@
+from src.app.models import db, User, SectionAISettings, OcrPromptSettings
+from werkzeug.security import generate_password_hash
+from flask import url_for
+
+
+def create_admin(app):
+    with app.app_context():
+        admin = User(
+            username="admin",
+            password=generate_password_hash("pw"),
+            role="admin",
+            is_first_connexion=False,
+        )
+        db.session.add(admin)
+        db.session.commit()
+        return admin.id
+
+
+def login(client, user_id):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user_id)
+        sess["_fresh"] = True
+
+
+def test_export_prompts_includes_section_and_ocr(app, client):
+    admin_id = create_admin(app)
+    login(client, admin_id)
+
+    with app.app_context():
+        sa = SectionAISettings.get_for("evaluation")
+        sa.system_prompt = "Eval Prompt"
+        ocr = OcrPromptSettings.get_current()
+        ocr.extraction_prompt = "OCR Prompt"
+        db.session.commit()
+
+    resp = client.get("/settings/prompts/export")
+    assert resp.status_code == 200
+    assert "attachment; filename=prompts.md" in resp.headers.get("Content-Disposition", "")
+    content = resp.data.decode()
+    assert "Eval Prompt" in content
+    assert "OCR Prompt" in content
+
+
+def test_settings_sidebar_has_export_link(app, client):
+    admin_id = create_admin(app)
+    login(client, admin_id)
+    with app.test_request_context():
+        export_url = url_for("settings.export_prompts")
+    resp = client.get("/settings/parametres")
+    assert resp.status_code == 200
+    assert export_url.encode() in resp.data


### PR DESCRIPTION
## Summary
- allow admins to download all configured prompts as a single markdown file
- add sidebar link for exporting prompts
- test prompt export via new settings route

## Testing
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68b32230f1d8832286a1e51932a9ae56