### PR TITLE
Allow renaming imported DOCX schemas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ Ce référentiel utilise des agents/outils pour automatiser des modifications de
 ## Règle essentielle
 - Toujours écrire des tests pertinents (pytest) pour couvrir le correctif ou la fonctionnalité ajoutée.
 - Toujours exécuter la suite de tests localement avec `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` pour accélérer l'exécution et s'assurer qu'elle passe avant de conclure la tâche.
+- Inclure et valider un jeton CSRF pour toute requête POST/PUT/DELETE modifiant l'état (champ `csrf_token` ou en-tête `X-CSRFToken`).
 
 ## Détails pratiques
 - Emplacement des tests: placez-les sous `tests/` avec le préfixe `test_*.py`.

--- a/src/app/routes/admin_docx_schema.py
+++ b/src/app/routes/admin_docx_schema.py
@@ -151,6 +151,23 @@ def docx_schema_page_edit(page_id):
     return jsonify({'success': True})
 
 
+@main.route('/docx_schema/<int:page_id>/rename', methods=['POST'])
+@role_required('admin')
+@ensure_profile_completed
+def docx_schema_page_rename(page_id):
+    """Met à jour uniquement le titre d'un schéma existant."""
+    page = DocxSchemaPage.query.get_or_404(page_id)
+    data = request.get_json() or {}
+    title = data.get('title')
+    if not title:
+        return jsonify({'error': 'Titre manquant.'}), 400
+    page.title = title
+    if isinstance(page.json_schema, dict):
+        page.json_schema['title'] = title
+    db.session.commit()
+    return jsonify({'success': True})
+
+
 @main.route('/docx_schema/<int:page_id>/delete', methods=['POST'])
 @role_required('admin')
 @ensure_profile_completed

--- a/src/app/templates/docx_schema_list.html
+++ b/src/app/templates/docx_schema_list.html
@@ -35,9 +35,10 @@ async function renameSchema(id) {
   const currentTitle = titleCell.textContent.trim();
   const newTitle = prompt('Nouveau titre:', currentTitle);
   if (!newTitle || newTitle === currentTitle) return;
+  const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
   const resp = await fetch(`/docx_schema/${id}/rename`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken, 'X-CSRF-Token': csrfToken },
     body: JSON.stringify({ title: newTitle })
   });
   if (resp.ok) {

--- a/src/app/templates/docx_schema_list.html
+++ b/src/app/templates/docx_schema_list.html
@@ -11,10 +11,11 @@
       {% for p in pages %}
       <tr>
         <td>{{ p.id }}</td>
-        <td>{{ p.title }}</td>
+        <td id="title-{{ p.id }}">{{ p.title }}</td>
         <td>
           <a class="btn btn-sm btn-primary" href="{{ url_for('main.docx_schema_page_view', page_id=p.id) }}">Voir</a>
           <a class="btn btn-sm btn-secondary" href="{{ url_for('main.docx_schema_page_json', page_id=p.id) }}">JSON</a>
+          <button type="button" class="btn btn-sm btn-warning" onclick="renameSchema({{ p.id }})">Renommer</button>
           <form method="POST" action="{{ url_for('main.docx_schema_page_delete', page_id=p.id) }}" class="d-inline">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button class="btn btn-sm btn-danger" onclick="return confirm('Supprimer ce schéma?')">Supprimer</button>
@@ -28,4 +29,22 @@
   <p>Aucun schéma validé.</p>
   {% endif %}
 </div>
+<script>
+async function renameSchema(id) {
+  const titleCell = document.getElementById(`title-${id}`);
+  const currentTitle = titleCell.textContent.trim();
+  const newTitle = prompt('Nouveau titre:', currentTitle);
+  if (!newTitle || newTitle === currentTitle) return;
+  const resp = await fetch(`/docx_schema/${id}/rename`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: newTitle })
+  });
+  if (resp.ok) {
+    titleCell.textContent = newTitle;
+  } else {
+    alert('Erreur lors de la mise à jour du titre');
+  }
+}
+</script>
 {% endblock %}

--- a/tests/test_docx_to_schema_ui.py
+++ b/tests/test_docx_to_schema_ui.py
@@ -154,6 +154,12 @@ def test_docx_schema_management(app, client):
     # List page includes it
     resp = client.get('/docx_schema')
     assert b'>Manage<' in resp.data
+    # Rename schema
+    resp = client.post(f'/docx_schema/{page_id}/rename', json={'title': 'Renamed'})
+    assert resp.status_code == 200
+    resp = client.get('/docx_schema')
+    assert b'>Renamed<' in resp.data
+    assert b'>Manage<' not in resp.data
     # Edit schema
     resp = client.post(f'/docx_schema/{page_id}/edit', json={'schema': {'title': 'Updated', 'type': 'object'}})
     assert resp.status_code == 200
@@ -167,7 +173,7 @@ def test_docx_schema_management(app, client):
     resp = client.post(f'/docx_schema/{page_id}/delete')
     assert resp.status_code == 302
     resp = client.get('/docx_schema')
-    assert b'>Manage<' not in resp.data
+    assert b'>Updated<' not in resp.data
 
 
 def test_docx_to_schema_prompts_page(app, client):


### PR DESCRIPTION
## Summary
- Add `/docx_schema/<id>/rename` endpoint to update a schema's title
- Add rename UI on `/docx_schema` list page
- Test renaming behavior

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b57898aba08322bebd96a6805af15e