### PR TITLE
Add AI prompt settings for data schema pages

### DIFF
--- a/src/app/routes/routes.py
+++ b/src/app/routes/routes.py
@@ -57,7 +57,8 @@ from ..models import (
     ElementCompetenceParCours,
     Cours,
     CoursProgramme,
-    ListeCegep
+    ListeCegep,
+    DocxSchemaPage
 )
 from ...extensions import limiter
 from ...utils.decorator import role_required, roles_required, ensure_profile_completed
@@ -85,7 +86,8 @@ def version():
 @login_required
 @ensure_profile_completed
 def parametres_alias():
-    return render_template('parametres.html')
+    docx_schemas = DocxSchemaPage.query.order_by(DocxSchemaPage.created_at.desc()).all()
+    return render_template('parametres.html', docx_schemas=docx_schemas)
 
 # Public: Health endpoint
 @main.route('/health')

--- a/src/app/templates/parametres.html
+++ b/src/app/templates/parametres.html
@@ -107,6 +107,11 @@
                         <a href="{{ url_for('main.docx_schema_pages') }}" class="list-group-item list-group-item-action {% if request.endpoint == 'main.docx_schema_pages' %}active{% endif %}">
                           <i class="bi bi-collection me-2"></i>Liste des schémas de données
                         </a>
+                        {% for s in docx_schemas %}
+                        <a href="{{ url_for('settings.docx_schema_prompt_settings', page_id=s.id) }}" class="list-group-item list-group-item-action {% if request.endpoint == 'settings.docx_schema_prompt_settings' and request.view_args.get('page_id') == s.id %}active{% endif %}">
+                          <i class="bi bi-filetype-json me-2"></i>Prompts – {{ s.title }}
+                        </a>
+                        {% endfor %}
                     </div>
                   </div>
                 </div>

--- a/src/app/templates/settings/docx_schema_prompts.html
+++ b/src/app/templates/settings/docx_schema_prompts.html
@@ -1,0 +1,28 @@
+{% extends "parametres.html" %}
+{% block parametres_content %}
+  <h1 class="mb-3">{{ page.title }} – Paramètres IA</h1>
+  <form method="POST" action="{{ url_for('settings.docx_schema_prompt_settings', page_id=page.id) }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+    <div class="mb-3">
+      <label class="form-label">{{ ai_form.system_prompt.label }}</label>
+      {{ ai_form.system_prompt(class_='form-control font-monospace', rows=12) }}
+    </div>
+    <div class="row g-3">
+      <div class="col-md-4">
+        <label class="form-label">{{ ai_form.ai_model.label }}</label>
+        {{ ai_form.ai_model(class_='form-select') }}
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">{{ ai_form.reasoning_effort.label }}</label>
+        {{ ai_form.reasoning_effort(class_='form-select') }}
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">{{ ai_form.verbosity.label }}</label>
+        {{ ai_form.verbosity(class_='form-select') }}
+      </div>
+    </div>
+    <div class="mt-3 text-end">
+      <button class="btn btn-primary" type="submit">Enregistrer</button>
+    </div>
+  </form>
+{% endblock %}

--- a/tests/test_docx_schema_prompts.py
+++ b/tests/test_docx_schema_prompts.py
@@ -1,0 +1,45 @@
+from werkzeug.security import generate_password_hash
+from src.app.models import User, db, OpenAIModel, SectionAISettings
+
+
+def _login(client, user_id):
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(user_id)
+        sess['_fresh'] = True
+
+
+def test_docx_schema_prompts_page(app, client):
+    with app.app_context():
+        admin = User(
+            username='admins',
+            password=generate_password_hash('pw'),
+            role='admin',
+            is_first_connexion=False,
+            openai_key='sk'
+        )
+        db.session.add(admin)
+        db.session.add(OpenAIModel(name='gpt-4o-mini', input_price=0.0, output_price=0.0))
+        db.session.commit()
+        admin_id = admin.id
+    _login(client, admin_id)
+    resp = client.post('/docx_to_schema/validate', json={'schema': {'title': 'Test', 'type': 'object'}, 'markdown': '# md'})
+    page_id = resp.get_json()['page_id']
+    resp = client.get('/parametres')
+    assert f'/settings/docx_schema/{page_id}/prompts'.encode() in resp.data
+    resp = client.get(f'/settings/docx_schema/{page_id}/prompts')
+    assert resp.status_code == 200
+    assert b'Prompt syst' in resp.data
+    resp = client.post(
+        f'/settings/docx_schema/{page_id}/prompts',
+        data={
+            'system_prompt': 'Custom',
+            'ai_model': '',
+            'reasoning_effort': '',
+            'verbosity': ''
+        },
+        follow_redirects=True
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        sa = SectionAISettings.query.filter_by(section=f'docx_schema_{page_id}').first()
+        assert sa and sa.system_prompt == 'Custom'


### PR DESCRIPTION
## Summary
- Support per-schema AI configuration via `/settings/docx_schema/<id>/prompts`
- Surface links to schema prompt pages in parameters sidebar
- Test saving custom system prompt for generated schemas

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5784618788322aefee624b5ab974e