### PR TITLE
feat: enhance docx schema preview

### DIFF
--- a/src/app/templates/docx_schema_preview.html
+++ b/src/app/templates/docx_schema_preview.html
@@ -5,6 +5,31 @@
 <div class="container mt-4">
   <h1 id="schemaPageTitle">{{ page.title }}</h1>
 
+  <div class="d-flex flex-column flex-sm-row gap-3 mb-4 align-items-center">
+    <button type="button" id="schemaImportBtn" class="btn btn-outline-primary d-flex align-items-center">
+      <i class="bi bi-file-earmark-arrow-up me-2"></i>
+      <span>Importer</span>
+    </button>
+    <button type="button" id="schemaGenerateBtn" class="btn btn-success d-flex align-items-center">
+      <i class="bi bi-box-arrow-up-right me-2"></i>
+      <span>Générer</span>
+    </button>
+    <button type="button" id="schemaImproveBtn" class="btn btn-outline-success d-flex align-items-center">
+      <i class="bi bi-magic me-2"></i>
+      <span>Améliorer</span>
+    </button>
+    <button type="button" id="schemaExportBtn" class="btn btn-primary d-flex align-items-center">
+      <i class="bi bi-file-earmark-word me-2"></i>
+      <span>Exporter</span>
+    </button>
+  </div>
+
+  <section class="mb-4">
+    <h2 class="h4 mb-3">Plan cadre</h2>
+    <form id="planCadreForm" class="d-flex flex-column gap-3"></form>
+    <button type="button" id="planCadreSaveBtn" class="btn btn-primary mt-2">Enregistrer</button>
+  </section>
+
   <div class="accordion" id="schemaAccordion">
     <div class="accordion-item">
       <h2 class="accordion-header" id="schemaHeadingTitle">
@@ -53,8 +78,8 @@
   </div>
 
   <div class="mt-3 d-flex gap-2">
-    <button id="schemaEditBtn" class="btn btn-primary" type="button">Éditer</button>
-    <a href="{{ url_for('main.docx_schema_pages') }}" class="btn btn-secondary">Retour</a>
+    <button id="schemaEditBtn" class="btn btn-secondary" type="button">Éditer</button>
+    <a href="{{ url_for('main.docx_schema_pages') }}" class="btn btn-outline-secondary">Retour</a>
   </div>
 
   <div class="modal fade" id="schemaEditModal" tabindex="-1" aria-labelledby="schemaEditLabel" aria-hidden="true">
@@ -99,6 +124,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const editModalEl = document.getElementById('schemaEditModal');
   const editTextarea = document.getElementById('schemaEditTextarea');
   const editSaveBtn = document.getElementById('schemaEditSaveBtn');
+  const planFormEl = document.getElementById('planCadreForm');
 
   function normalizePlanSchema(node) {
     if (!node || typeof node !== 'object') return node;
@@ -169,6 +195,72 @@ document.addEventListener('DOMContentLoaded', () => {
     return walk(node);
   }
 
+  function renderPlanCadreForm(schema, parent, path='root') {
+    if (!schema || !parent) return;
+    if (schema.type === 'object' && schema.properties) {
+      for (const [key, prop] of Object.entries(schema.properties)) {
+        renderPlanCadreForm(prop, parent, path === 'root' ? key : `${path}.${key}`);
+      }
+      return;
+    }
+    if (schema.type === 'array' && schema.items) {
+      const container = document.createElement('div');
+      container.className = 'mb-3';
+
+      const label = document.createElement('label');
+      label.className = 'form-label';
+      label.textContent = schema.title || path;
+      container.appendChild(label);
+
+      const list = document.createElement('div');
+      list.className = 'd-flex flex-column gap-2';
+      container.appendChild(list);
+
+      function addItem() {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'input-group';
+        const input = document.createElement('input');
+        input.className = 'form-control';
+        input.name = path + '[]';
+        wrapper.appendChild(input);
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'btn btn-outline-danger remove-form-array-item';
+        btn.innerHTML = '<i class="bi bi-x"></i>';
+        btn.addEventListener('click', () => wrapper.remove());
+        wrapper.appendChild(btn);
+        list.appendChild(wrapper);
+      }
+
+      const addBtn = document.createElement('button');
+      addBtn.type = 'button';
+      addBtn.className = 'btn btn-outline-primary btn-sm add-form-array-item';
+      addBtn.textContent = 'Ajouter';
+      addBtn.addEventListener('click', addItem);
+      container.appendChild(addBtn);
+
+      parent.appendChild(container);
+      addItem();
+      return;
+    }
+
+    const field = document.createElement('div');
+    field.className = 'mb-3';
+    const label = document.createElement('label');
+    label.className = 'form-label';
+    label.setAttribute('for', path);
+    label.textContent = schema.title || path;
+    const input = document.createElement('input');
+    input.className = 'form-control';
+    input.id = path;
+    input.name = path;
+    if (schema.type === 'number' || schema.type === 'integer') input.type = 'number';
+    else input.type = 'text';
+    field.appendChild(label);
+    field.appendChild(input);
+    parent.appendChild(field);
+  }
+
   function renderSchemaAccordion(schema, parent, name='root', path='root', required=[]) {
     if (!schema || !parent) return;
     const type = schema.type || (schema.$ref ? schema.$ref : 'any');
@@ -220,7 +312,29 @@ document.addEventListener('DOMContentLoaded', () => {
         renderSchemaAccordion(val, inner, key, `${path}.${key}`, childRequired);
       }
     } else if (schema.type === 'array' && schema.items) {
-      renderSchemaAccordion(schema.items, body, 'items', `${path}[]`);
+      const list = document.createElement('div');
+      list.className = 'array-container';
+      body.appendChild(list);
+      const addBtn = document.createElement('button');
+      addBtn.type = 'button';
+      addBtn.className = 'btn btn-sm btn-outline-primary add-array-item mb-2';
+      addBtn.innerHTML = '<i class="bi bi-plus-circle"></i> Ajouter';
+      body.insertBefore(addBtn, list);
+      const addItem = () => {
+        const idx = list.children.length;
+        const wrapper = document.createElement('div');
+        wrapper.className = 'mb-2';
+        renderSchemaAccordion(schema.items, wrapper, `${name}[${idx}]`, `${path}[${idx}]`);
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'btn btn-sm btn-outline-danger remove-array-item ms-2';
+        removeBtn.innerHTML = '<i class="bi bi-trash"></i>';
+        removeBtn.addEventListener('click', () => wrapper.remove());
+        wrapper.appendChild(removeBtn);
+        list.appendChild(wrapper);
+      };
+      addBtn.addEventListener('click', addItem);
+      addItem();
     } else if (schema.$ref) {
       const p = document.createElement('div');
       p.textContent = schema.$ref;
@@ -300,6 +414,36 @@ document.addEventListener('DOMContentLoaded', () => {
     return walk(schema, schema.title || 'root');
   }
 
+  function enhanceMarkdownLists(root) {
+    if (!root) return;
+    root.querySelectorAll('ul').forEach((ul) => {
+      const addBtn = document.createElement('button');
+      addBtn.type = 'button';
+      addBtn.className = 'btn btn-sm btn-outline-primary add-list-item mb-2';
+      addBtn.innerHTML = '<i class="bi bi-plus-circle"></i> Ajouter';
+      ul.parentNode.insertBefore(addBtn, ul);
+      addBtn.addEventListener('click', () => {
+        const li = document.createElement('li');
+        li.contentEditable = 'true';
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'btn btn-sm btn-outline-danger ms-2 remove-list-item';
+        removeBtn.innerHTML = '<i class="bi bi-trash"></i>';
+        removeBtn.addEventListener('click', () => li.remove());
+        li.appendChild(removeBtn);
+        ul.appendChild(li);
+      });
+      ul.querySelectorAll('li').forEach((li) => {
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'btn btn-sm btn-outline-danger ms-2 remove-list-item';
+        removeBtn.innerHTML = '<i class="bi bi-trash"></i>';
+        removeBtn.addEventListener('click', () => li.remove());
+        li.appendChild(removeBtn);
+      });
+    });
+  }
+
   let currentSchema = normalizePlanSchema(schemaData);
   function renderAll() {
     pageTitleEl.textContent = currentSchema.title || '';
@@ -309,9 +453,14 @@ document.addEventListener('DOMContentLoaded', () => {
     schemaEl.textContent = JSON.stringify(schemaData, null, 2);
     if (markdownEl && markdownData) {
       markdownEl.innerHTML = window.marked.parse(markdownData);
+      enhanceMarkdownLists(markdownEl);
     }
     renderSchemaAccordion(currentSchema, schemaTreeEl, 'root', 'root');
     renderSchemaGraph(currentSchema);
+    if (planFormEl) {
+      planFormEl.innerHTML = '';
+      renderPlanCadreForm(currentSchema, planFormEl);
+    }
   }
   renderAll();
 

--- a/src/app/templates/docx_schema_preview.html
+++ b/src/app/templates/docx_schema_preview.html
@@ -293,12 +293,14 @@ document.addEventListener('DOMContentLoaded', () => {
       list.className = 'd-flex flex-column gap-2';
       container.appendChild(list);
 
+      const itemName = normalizeName(schema.items.title || schema.title || path);
+      const itemPath = path === 'root' ? itemName : `${path}.${itemName}`;
+
       function addItem() {
-        const idx = list.children.length;
         if (schema.items.type === 'object') {
           const wrapper = document.createElement('div');
           wrapper.className = 'border rounded p-2 position-relative';
-          renderPlanCadreForm(schema.items, wrapper, path);
+          renderPlanCadreForm(schema.items, wrapper, itemPath);
           const btn = document.createElement('button');
           btn.type = 'button';
           btn.className = 'btn btn-outline-danger btn-sm position-absolute top-0 end-0 remove-form-array-item';
@@ -424,11 +426,13 @@ document.addEventListener('DOMContentLoaded', () => {
       addBtn.className = 'btn btn-sm btn-outline-primary add-array-item mb-2';
       addBtn.innerHTML = '<i class="bi bi-plus-circle"></i> Ajouter';
       body.insertBefore(addBtn, list);
+      const itemName = normalizeName(schema.items.title || name);
+      const itemPath = path === 'root' ? itemName : `${path}.${itemName}`;
       const addItem = () => {
         const idx = list.children.length;
         const wrapper = document.createElement('div');
         wrapper.className = 'mb-2';
-          renderSchemaAccordion(schema.items, wrapper, `${name}[${idx}]`, path, schema.items.required || []);
+        renderSchemaAccordion(schema.items, wrapper, `${name}[${idx}]`, itemPath, schema.items.required || []);
         const removeBtn = document.createElement('button');
         removeBtn.type = 'button';
         removeBtn.className = 'btn btn-sm btn-outline-danger remove-array-item ms-2';
@@ -526,7 +530,8 @@ document.addEventListener('DOMContentLoaded', () => {
           return walk(v, k, childPath);
         });
       } else if (node.type === 'array' && node.items) {
-        const childPath = path;
+        const itemName = normalizeName(node.items.title || name);
+        const childPath = path === 'root' ? itemName : `${path}.${itemName}`;
         out.children = [walk(node.items, name + '[]', childPath)];
       }
       return out;

--- a/src/app/templates/docx_schema_preview.html
+++ b/src/app/templates/docx_schema_preview.html
@@ -126,6 +126,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const editSaveBtn = document.getElementById('schemaEditSaveBtn');
   const planFormEl = document.getElementById('planCadreForm');
   let markdownOrderMap = {};
+  const normalizedMarkdown = normalizeName(markdownData || '');
   function normalizeName(str) {
     return (str || '')
       .toString()
@@ -153,6 +154,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const parent = stack.slice(0, -1).join('.') || 'root';
             addOrder(parent, stack[t.depth - 1]);
           } else if (t.type === 'list') {
+            if (stack.length === 0) continue;
             const parent = stack.join('.') || 'root';
             t.items.forEach(item => {
               const name = normalizeName(item.text);
@@ -173,6 +175,10 @@ document.addEventListener('DOMContentLoaded', () => {
   function getMdOrder(path) {
     const key = normalizeName(path.replace(/\[[0-9]+\]/g, '')) || 'root';
     return markdownOrderMap[key] || [];
+  }
+  function getMarkdownIndex(name) {
+    const idx = normalizedMarkdown.indexOf(name);
+    return idx === -1 ? Number.MAX_SAFE_INTEGER : idx;
   }
 
   function normalizePlanSchema(node) {
@@ -254,10 +260,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const nameB = normalizeName(bv.title || bk);
         const ia = mdOrder.indexOf(nameA);
         const ib = mdOrder.indexOf(nameB);
-        if (ia === -1 && ib === -1) return 0;
-        if (ia === -1) return 1;
-        if (ib === -1) return -1;
-        return ia - ib;
+        const posA = ia !== -1 ? ia : getMarkdownIndex(nameA);
+        const posB = ib !== -1 ? ib : getMarkdownIndex(nameB);
+        return posA - posB;
       });
       const container = path === 'root' ? parent : document.createElement('div');
       if (path !== 'root') {
@@ -401,10 +406,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const nameB = normalizeName(bv.title || bk);
         const ia = mdOrder.indexOf(nameA);
         const ib = mdOrder.indexOf(nameB);
-        if (ia === -1 && ib === -1) return 0;
-        if (ia === -1) return 1;
-        if (ib === -1) return -1;
-        return ia - ib;
+        const posA = ia !== -1 ? ia : getMarkdownIndex(nameA);
+        const posB = ib !== -1 ? ib : getMarkdownIndex(nameB);
+        return posA - posB;
       });
       for (const [key, val] of entries) {
         const childName = normalizeName(val.title || key);
@@ -512,10 +516,9 @@ document.addEventListener('DOMContentLoaded', () => {
           const nameB = normalizeName(bv.title || bk);
           const ia = mdOrder.indexOf(nameA);
           const ib = mdOrder.indexOf(nameB);
-          if (ia === -1 && ib === -1) return 0;
-          if (ia === -1) return 1;
-          if (ib === -1) return -1;
-          return ia - ib;
+          const posA = ia !== -1 ? ia : getMarkdownIndex(nameA);
+          const posB = ib !== -1 ? ib : getMarkdownIndex(nameB);
+          return posA - posB;
         });
         out.children = entries.map(([k,v]) => {
           const childName = normalizeName(v.title || k);

--- a/src/app/templates/docx_schema_preview.html
+++ b/src/app/templates/docx_schema_preview.html
@@ -125,9 +125,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const editTextarea = document.getElementById('schemaEditTextarea');
   const editSaveBtn = document.getElementById('schemaEditSaveBtn');
   const planFormEl = document.getElementById('planCadreForm');
-  const markdownOrderMap = (() => {
+  let markdownOrderMap = {};
+  function buildMarkdownOrderMap(markdown) {
     try {
-      const tokens = marked.lexer(markdownData || '');
+      const tokens = marked.lexer(markdown || '');
       const map = { root: [] };
       const stack = [];
       function addOrder(path, name) {
@@ -159,7 +160,7 @@ document.addEventListener('DOMContentLoaded', () => {
       process(tokens);
       return map;
     } catch (e) { return { root: [] }; }
-  })();
+  }
   function getMdOrder(path) {
     const key = path.replace(/\[[0-9]+\]/g, '') || 'root';
     return markdownOrderMap[key] || [];
@@ -258,7 +259,9 @@ document.addEventListener('DOMContentLoaded', () => {
         container.appendChild(legend);
       }
       for (const [key, prop] of entries) {
-        renderPlanCadreForm(prop, container, path === 'root' ? key : `${path}.${key}`);
+        const childName = (prop.title || key).toLowerCase();
+        const childPath = path === 'root' ? childName : `${path}.${childName}`;
+        renderPlanCadreForm(prop, container, childPath);
       }
       if (path !== 'root') parent.appendChild(container);
       return;
@@ -281,7 +284,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (schema.items.type === 'object') {
           const wrapper = document.createElement('div');
           wrapper.className = 'border rounded p-2 position-relative';
-          renderPlanCadreForm(schema.items, wrapper, `${path}[${idx}]`);
+          renderPlanCadreForm(schema.items, wrapper, path);
           const btn = document.createElement('button');
           btn.type = 'button';
           btn.className = 'btn btn-outline-danger btn-sm position-absolute top-0 end-0 remove-form-array-item';
@@ -395,7 +398,9 @@ document.addEventListener('DOMContentLoaded', () => {
         return ia - ib;
       });
       for (const [key, val] of entries) {
-        renderSchemaAccordion(val, inner, key, `${path}.${key}`, childRequired);
+        const childName = (val.title || key).toLowerCase();
+        const childPath = path === 'root' ? childName : `${path}.${childName}`;
+        renderSchemaAccordion(val, inner, key, childPath, childRequired);
       }
     } else if (schema.type === 'array' && schema.items) {
       const list = document.createElement('div');
@@ -410,7 +415,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const idx = list.children.length;
         const wrapper = document.createElement('div');
         wrapper.className = 'mb-2';
-        renderSchemaAccordion(schema.items, wrapper, `${name}[${idx}]`, `${path}[${idx}]`);
+          renderSchemaAccordion(schema.items, wrapper, `${name}[${idx}]`, path, schema.items.required || []);
         const removeBtn = document.createElement('button');
         removeBtn.type = 'button';
         removeBtn.className = 'btn btn-sm btn-outline-danger remove-array-item ms-2';
@@ -504,11 +509,12 @@ document.addEventListener('DOMContentLoaded', () => {
           return ia - ib;
         });
         out.children = entries.map(([k,v]) => {
-          const childPath = path === 'root' ? k : `${path}.${k}`;
+          const childName = (v.title || k).toLowerCase();
+          const childPath = path === 'root' ? childName : `${path}.${childName}`;
           return walk(v, k, childPath);
         });
       } else if (node.type === 'array' && node.items) {
-        const childPath = path === 'root' ? name : `${path}.${name}`;
+        const childPath = path;
         out.children = [walk(node.items, name + '[]', childPath)];
       }
       return out;
@@ -548,6 +554,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   let currentSchema = normalizePlanSchema(schemaData);
   function renderAll() {
+    markdownOrderMap = buildMarkdownOrderMap(markdownData);
     pageTitleEl.textContent = currentSchema.title || '';
     document.title = currentSchema.title || document.title;
     titleEl.textContent = currentSchema.title || '';

--- a/src/app/templates/docx_schema_preview.html
+++ b/src/app/templates/docx_schema_preview.html
@@ -356,7 +356,18 @@ document.addEventListener('DOMContentLoaded', () => {
       inner.id = `${itemId}-inner`;
       body.appendChild(inner);
       const childRequired = schema.required || [];
-      for (const [key, val] of Object.entries(schema.properties)) {
+      const entries = Object.entries(schema.properties);
+      entries.sort(([ak, av], [bk, bv]) => {
+        const nameA = (av.title || ak).toLowerCase();
+        const nameB = (bv.title || bk).toLowerCase();
+        const ia = markdownOrder.indexOf(nameA);
+        const ib = markdownOrder.indexOf(nameB);
+        if (ia === -1 && ib === -1) return 0;
+        if (ia === -1) return 1;
+        if (ib === -1) return -1;
+        return ia - ib;
+      });
+      for (const [key, val] of entries) {
         renderSchemaAccordion(val, inner, key, `${path}.${key}`, childRequired);
       }
     } else if (schema.type === 'array' && schema.items) {
@@ -453,7 +464,18 @@ document.addEventListener('DOMContentLoaded', () => {
     function walk(node, name) {
       const out = { name, type: node.type || 'any' };
       if (node.type === 'object' && node.properties) {
-        out.children = Object.entries(node.properties).map(([k,v]) => walk(v, k));
+        const entries = Object.entries(node.properties);
+        entries.sort(([ak, av], [bk, bv]) => {
+          const nameA = (av.title || ak).toLowerCase();
+          const nameB = (bv.title || bk).toLowerCase();
+          const ia = markdownOrder.indexOf(nameA);
+          const ib = markdownOrder.indexOf(nameB);
+          if (ia === -1 && ib === -1) return 0;
+          if (ia === -1) return 1;
+          if (ib === -1) return -1;
+          return ia - ib;
+        });
+        out.children = entries.map(([k,v]) => walk(v, k));
       } else if (node.type === 'array' && node.items) {
         out.children = [walk(node.items, name + '[]')];
       }

--- a/src/app/templates/docx_schema_preview.html
+++ b/src/app/templates/docx_schema_preview.html
@@ -125,20 +125,45 @@ document.addEventListener('DOMContentLoaded', () => {
   const editTextarea = document.getElementById('schemaEditTextarea');
   const editSaveBtn = document.getElementById('schemaEditSaveBtn');
   const planFormEl = document.getElementById('planCadreForm');
-  const markdownOrder = (() => {
+  const markdownOrderMap = (() => {
     try {
       const tokens = marked.lexer(markdownData || '');
-      const order = [];
-      for (const t of tokens) {
-        if (t.type === 'heading') {
-          order.push(t.text.trim().toLowerCase());
-        } else if (t.type === 'list') {
-          t.items.forEach(i => order.push(i.text.trim().toLowerCase()));
+      const map = { root: [] };
+      const stack = [];
+      function addOrder(path, name) {
+        const key = path || 'root';
+        if (!map[key]) map[key] = [];
+        map[key].push(name);
+      }
+      function process(tok) {
+        for (const t of tok) {
+          if (t.type === 'heading') {
+            stack.length = t.depth - 1;
+            stack[t.depth - 1] = t.text.trim().toLowerCase();
+            const parent = stack.slice(0, -1).join('.') || 'root';
+            addOrder(parent, stack[t.depth - 1]);
+          } else if (t.type === 'list') {
+            const parent = stack.join('.') || 'root';
+            t.items.forEach(item => {
+              const name = item.text.trim().toLowerCase();
+              addOrder(parent, name);
+              if (item.tokens) {
+                stack.push(name);
+                process(item.tokens);
+                stack.pop();
+              }
+            });
+          }
         }
       }
-      return order;
-    } catch (e) { return []; }
+      process(tokens);
+      return map;
+    } catch (e) { return { root: [] }; }
   })();
+  function getMdOrder(path) {
+    const key = path.replace(/\[[0-9]+\]/g, '') || 'root';
+    return markdownOrderMap[key] || [];
+  }
 
   function normalizePlanSchema(node) {
     if (!node || typeof node !== 'object') return node;
@@ -213,11 +238,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!schema || !parent) return;
     if (schema.type === 'object' && schema.properties) {
       const entries = Object.entries(schema.properties);
+      const mdOrder = getMdOrder(path);
       entries.sort(([ak, av], [bk, bv]) => {
         const nameA = (av.title || ak).toLowerCase();
         const nameB = (bv.title || bk).toLowerCase();
-        const ia = markdownOrder.indexOf(nameA);
-        const ib = markdownOrder.indexOf(nameB);
+        const ia = mdOrder.indexOf(nameA);
+        const ib = mdOrder.indexOf(nameB);
         if (ia === -1 && ib === -1) return 0;
         if (ia === -1) return 1;
         if (ib === -1) return -1;
@@ -357,11 +383,12 @@ document.addEventListener('DOMContentLoaded', () => {
       body.appendChild(inner);
       const childRequired = schema.required || [];
       const entries = Object.entries(schema.properties);
+      const mdOrder = getMdOrder(path);
       entries.sort(([ak, av], [bk, bv]) => {
         const nameA = (av.title || ak).toLowerCase();
         const nameB = (bv.title || bk).toLowerCase();
-        const ia = markdownOrder.indexOf(nameA);
-        const ib = markdownOrder.indexOf(nameB);
+        const ia = mdOrder.indexOf(nameA);
+        const ib = mdOrder.indexOf(nameB);
         if (ia === -1 && ib === -1) return 0;
         if (ia === -1) return 1;
         if (ib === -1) return -1;
@@ -461,27 +488,32 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function buildTree(schema) {
-    function walk(node, name) {
+    function walk(node, name, path) {
       const out = { name, type: node.type || 'any' };
       if (node.type === 'object' && node.properties) {
         const entries = Object.entries(node.properties);
+        const mdOrder = getMdOrder(path);
         entries.sort(([ak, av], [bk, bv]) => {
           const nameA = (av.title || ak).toLowerCase();
           const nameB = (bv.title || bk).toLowerCase();
-          const ia = markdownOrder.indexOf(nameA);
-          const ib = markdownOrder.indexOf(nameB);
+          const ia = mdOrder.indexOf(nameA);
+          const ib = mdOrder.indexOf(nameB);
           if (ia === -1 && ib === -1) return 0;
           if (ia === -1) return 1;
           if (ib === -1) return -1;
           return ia - ib;
         });
-        out.children = entries.map(([k,v]) => walk(v, k));
+        out.children = entries.map(([k,v]) => {
+          const childPath = path === 'root' ? k : `${path}.${k}`;
+          return walk(v, k, childPath);
+        });
       } else if (node.type === 'array' && node.items) {
-        out.children = [walk(node.items, name + '[]')];
+        const childPath = path === 'root' ? name : `${path}.${name}`;
+        out.children = [walk(node.items, name + '[]', childPath)];
       }
       return out;
     }
-    return walk(schema, schema.title || 'root');
+    return walk(schema, schema.title || 'root', 'root');
   }
 
   function enhanceMarkdownLists(root) {

--- a/src/app/templates/docx_schema_preview.html
+++ b/src/app/templates/docx_schema_preview.html
@@ -126,6 +126,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const editSaveBtn = document.getElementById('schemaEditSaveBtn');
   const planFormEl = document.getElementById('planCadreForm');
   let markdownOrderMap = {};
+  function normalizeName(str) {
+    return (str || '')
+      .toString()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-zA-Z0-9]+/g, ' ')
+      .trim()
+      .toLowerCase();
+  }
   function buildMarkdownOrderMap(markdown) {
     try {
       const tokens = marked.lexer(markdown || '');
@@ -140,13 +149,13 @@ document.addEventListener('DOMContentLoaded', () => {
         for (const t of tok) {
           if (t.type === 'heading') {
             stack.length = t.depth - 1;
-            stack[t.depth - 1] = t.text.trim().toLowerCase();
+            stack[t.depth - 1] = normalizeName(t.text);
             const parent = stack.slice(0, -1).join('.') || 'root';
             addOrder(parent, stack[t.depth - 1]);
           } else if (t.type === 'list') {
             const parent = stack.join('.') || 'root';
             t.items.forEach(item => {
-              const name = item.text.trim().toLowerCase();
+              const name = normalizeName(item.text);
               addOrder(parent, name);
               if (item.tokens) {
                 stack.push(name);
@@ -162,7 +171,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch (e) { return { root: [] }; }
   }
   function getMdOrder(path) {
-    const key = path.replace(/\[[0-9]+\]/g, '') || 'root';
+    const key = normalizeName(path.replace(/\[[0-9]+\]/g, '')) || 'root';
     return markdownOrderMap[key] || [];
   }
 
@@ -241,8 +250,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const entries = Object.entries(schema.properties);
       const mdOrder = getMdOrder(path);
       entries.sort(([ak, av], [bk, bv]) => {
-        const nameA = (av.title || ak).toLowerCase();
-        const nameB = (bv.title || bk).toLowerCase();
+        const nameA = normalizeName(av.title || ak);
+        const nameB = normalizeName(bv.title || bk);
         const ia = mdOrder.indexOf(nameA);
         const ib = mdOrder.indexOf(nameB);
         if (ia === -1 && ib === -1) return 0;
@@ -259,7 +268,7 @@ document.addEventListener('DOMContentLoaded', () => {
         container.appendChild(legend);
       }
       for (const [key, prop] of entries) {
-        const childName = (prop.title || key).toLowerCase();
+        const childName = normalizeName(prop.title || key);
         const childPath = path === 'root' ? childName : `${path}.${childName}`;
         renderPlanCadreForm(prop, container, childPath);
       }
@@ -388,8 +397,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const entries = Object.entries(schema.properties);
       const mdOrder = getMdOrder(path);
       entries.sort(([ak, av], [bk, bv]) => {
-        const nameA = (av.title || ak).toLowerCase();
-        const nameB = (bv.title || bk).toLowerCase();
+        const nameA = normalizeName(av.title || ak);
+        const nameB = normalizeName(bv.title || bk);
         const ia = mdOrder.indexOf(nameA);
         const ib = mdOrder.indexOf(nameB);
         if (ia === -1 && ib === -1) return 0;
@@ -398,7 +407,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return ia - ib;
       });
       for (const [key, val] of entries) {
-        const childName = (val.title || key).toLowerCase();
+        const childName = normalizeName(val.title || key);
         const childPath = path === 'root' ? childName : `${path}.${childName}`;
         renderSchemaAccordion(val, inner, key, childPath, childRequired);
       }
@@ -499,8 +508,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const entries = Object.entries(node.properties);
         const mdOrder = getMdOrder(path);
         entries.sort(([ak, av], [bk, bv]) => {
-          const nameA = (av.title || ak).toLowerCase();
-          const nameB = (bv.title || bk).toLowerCase();
+          const nameA = normalizeName(av.title || ak);
+          const nameB = normalizeName(bv.title || bk);
           const ia = mdOrder.indexOf(nameA);
           const ib = mdOrder.indexOf(nameB);
           if (ia === -1 && ib === -1) return 0;
@@ -509,7 +518,7 @@ document.addEventListener('DOMContentLoaded', () => {
           return ia - ib;
         });
         out.children = entries.map(([k,v]) => {
-          const childName = (v.title || k).toLowerCase();
+          const childName = normalizeName(v.title || k);
           const childPath = path === 'root' ? childName : `${path}.${childName}`;
           return walk(v, k, childPath);
         });

--- a/src/app/templates/docx_schema_preview.html
+++ b/src/app/templates/docx_schema_preview.html
@@ -125,6 +125,20 @@ document.addEventListener('DOMContentLoaded', () => {
   const editTextarea = document.getElementById('schemaEditTextarea');
   const editSaveBtn = document.getElementById('schemaEditSaveBtn');
   const planFormEl = document.getElementById('planCadreForm');
+  const markdownOrder = (() => {
+    try {
+      const tokens = marked.lexer(markdownData || '');
+      const order = [];
+      for (const t of tokens) {
+        if (t.type === 'heading') {
+          order.push(t.text.trim().toLowerCase());
+        } else if (t.type === 'list') {
+          t.items.forEach(i => order.push(i.text.trim().toLowerCase()));
+        }
+      }
+      return order;
+    } catch (e) { return []; }
+  })();
 
   function normalizePlanSchema(node) {
     if (!node || typeof node !== 'object') return node;
@@ -198,9 +212,29 @@ document.addEventListener('DOMContentLoaded', () => {
   function renderPlanCadreForm(schema, parent, path='root') {
     if (!schema || !parent) return;
     if (schema.type === 'object' && schema.properties) {
-      for (const [key, prop] of Object.entries(schema.properties)) {
-        renderPlanCadreForm(prop, parent, path === 'root' ? key : `${path}.${key}`);
+      const entries = Object.entries(schema.properties);
+      entries.sort(([ak, av], [bk, bv]) => {
+        const nameA = (av.title || ak).toLowerCase();
+        const nameB = (bv.title || bk).toLowerCase();
+        const ia = markdownOrder.indexOf(nameA);
+        const ib = markdownOrder.indexOf(nameB);
+        if (ia === -1 && ib === -1) return 0;
+        if (ia === -1) return 1;
+        if (ib === -1) return -1;
+        return ia - ib;
+      });
+      const container = path === 'root' ? parent : document.createElement('div');
+      if (path !== 'root') {
+        container.className = 'border rounded p-2 mb-3';
+        const legend = document.createElement('h6');
+        legend.textContent = schema.title || path;
+        legend.className = 'fw-bold';
+        container.appendChild(legend);
       }
+      for (const [key, prop] of entries) {
+        renderPlanCadreForm(prop, container, path === 'root' ? key : `${path}.${key}`);
+      }
+      if (path !== 'root') parent.appendChild(container);
       return;
     }
     if (schema.type === 'array' && schema.items) {
@@ -217,19 +251,33 @@ document.addEventListener('DOMContentLoaded', () => {
       container.appendChild(list);
 
       function addItem() {
-        const wrapper = document.createElement('div');
-        wrapper.className = 'input-group';
-        const input = document.createElement('input');
-        input.className = 'form-control';
-        input.name = path + '[]';
-        wrapper.appendChild(input);
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'btn btn-outline-danger remove-form-array-item';
-        btn.innerHTML = '<i class="bi bi-x"></i>';
-        btn.addEventListener('click', () => wrapper.remove());
-        wrapper.appendChild(btn);
-        list.appendChild(wrapper);
+        const idx = list.children.length;
+        if (schema.items.type === 'object') {
+          const wrapper = document.createElement('div');
+          wrapper.className = 'border rounded p-2 position-relative';
+          renderPlanCadreForm(schema.items, wrapper, `${path}[${idx}]`);
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'btn btn-outline-danger btn-sm position-absolute top-0 end-0 remove-form-array-item';
+          btn.innerHTML = '<i class="bi bi-x"></i>';
+          btn.addEventListener('click', () => wrapper.remove());
+          wrapper.appendChild(btn);
+          list.appendChild(wrapper);
+        } else {
+          const wrapper = document.createElement('div');
+          wrapper.className = 'input-group';
+          const input = document.createElement('input');
+          input.className = 'form-control';
+          input.name = `${path}[]`;
+          wrapper.appendChild(input);
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'btn btn-outline-danger remove-form-array-item';
+          btn.innerHTML = '<i class="bi bi-x"></i>';
+          btn.addEventListener('click', () => wrapper.remove());
+          wrapper.appendChild(btn);
+          list.appendChild(wrapper);
+        }
       }
 
       const addBtn = document.createElement('button');

--- a/tests/test_docx_to_schema_ui.py
+++ b/tests/test_docx_to_schema_ui.py
@@ -295,13 +295,15 @@ def test_docx_schema_preview_plan_form_order_and_nested(app, client):
             }
         }
     }
-    markdown = '## Section\n## Résumé'
+    markdown = '## Section\n- Titre\n- Note\n## Résumé'
     resp = client.post('/docx_to_schema/validate', json={'schema': schema, 'markdown': markdown})
     assert resp.status_code == 201
     page_id = resp.get_json()['page_id']
     resp = client.get(f'/docx_schema/{page_id}')
     data = resp.data.decode('utf-8')
-    assert 'markdownOrder' in data
+    assert 'markdownOrderMap' in data
+    assert 'getMdOrder(path)' in data
+    assert 'path.replace(/\\[[0-9]+\\]/g, \'\')' in data
+    assert data.count('getMdOrder(') >= 3
     assert 'position-absolute top-0 end-0 remove-form-array-item' in data
-    assert data.count('markdownOrder.indexOf') >= 3
     assert 'Section' in data

--- a/tests/test_docx_to_schema_ui.py
+++ b/tests/test_docx_to_schema_ui.py
@@ -1,5 +1,6 @@
 from werkzeug.security import generate_password_hash
 from src.app.models import User, db, OpenAIModel
+from html import unescape
 
 
 def _login(client, user_id):
@@ -300,11 +301,11 @@ def test_docx_schema_preview_plan_form_order_and_nested(app, client):
     assert resp.status_code == 201
     page_id = resp.get_json()['page_id']
     resp = client.get(f'/docx_schema/{page_id}')
-    data = resp.data.decode('utf-8')
+    data = unescape(resp.data.decode('utf-8'))
     assert 'markdownOrderMap' in data
     assert 'buildMarkdownOrderMap' in data
     assert 'markdownOrderMap = buildMarkdownOrderMap(markdownData);' in data
     assert 'path.replace(/\\[[0-9]+\\]/g, \'\')' in data
     assert data.count('getMdOrder(') >= 3
     assert 'position-absolute top-0 end-0 remove-form-array-item' in data
-    assert 'Section' in data
+    assert 'normalizeName(' in data

--- a/tests/test_docx_to_schema_ui.py
+++ b/tests/test_docx_to_schema_ui.py
@@ -281,6 +281,7 @@ def test_docx_schema_preview_plan_form_order_and_nested(app, client):
         'title': 'Form',
         'type': 'object',
         'properties': {
+            'summary': {'type': 'string', 'title': 'Résumé'},
             'section': {
                 'title': 'Section',
                 'type': 'array',
@@ -291,8 +292,7 @@ def test_docx_schema_preview_plan_form_order_and_nested(app, client):
                         'notes': {'type': 'array', 'items': {'type': 'string', 'title': 'Note'}}
                     }
                 }
-            },
-            'summary': {'type': 'string', 'title': 'Résumé'}
+            }
         }
     }
     markdown = '## Section\n## Résumé'
@@ -303,4 +303,5 @@ def test_docx_schema_preview_plan_form_order_and_nested(app, client):
     data = resp.data.decode('utf-8')
     assert 'markdownOrder' in data
     assert 'position-absolute top-0 end-0 remove-form-array-item' in data
+    assert data.count('markdownOrder.indexOf') >= 3
     assert 'Section' in data

--- a/tests/test_docx_to_schema_ui.py
+++ b/tests/test_docx_to_schema_ui.py
@@ -302,7 +302,8 @@ def test_docx_schema_preview_plan_form_order_and_nested(app, client):
     resp = client.get(f'/docx_schema/{page_id}')
     data = resp.data.decode('utf-8')
     assert 'markdownOrderMap' in data
-    assert 'getMdOrder(path)' in data
+    assert 'buildMarkdownOrderMap' in data
+    assert 'markdownOrderMap = buildMarkdownOrderMap(markdownData);' in data
     assert 'path.replace(/\\[[0-9]+\\]/g, \'\')' in data
     assert data.count('getMdOrder(') >= 3
     assert 'position-absolute top-0 end-0 remove-form-array-item' in data


### PR DESCRIPTION
## Summary
- add import/generate/improve/export buttons to DOCX schema preview
- allow interactive array and Markdown list editing via Bootstrap controls
- add Plan cadre form generated from JSON schema with dynamic array inputs
- cover new form elements with tests

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5772dcdd88322a6faff8d98d846fb