### PR TITLE
Add import/generation/improvement tabs for schema prompts

### DIFF
--- a/src/app/routes/settings.py
+++ b/src/app/routes/settings.py
@@ -954,19 +954,55 @@ def docx_to_schema_prompt_settings():
 def docx_schema_prompt_settings(page_id):
     """Configurer le prompt système et les paramètres IA pour un schéma de données spécifique."""
     page = DocxSchemaPage.query.get_or_404(page_id)
-    section_key = f'docx_schema_{page_id}'
-    sa = SectionAISettings.get_for(section_key)
-    ai_form = SectionAISettingsForm(obj=sa)
-    if request.method == 'GET' and not (sa.system_prompt and sa.system_prompt.strip()):
-        ai_form.system_prompt.data = (
-            "Tu es un assistant qui retourne une sortie strictement conforme au schéma JSON fourni."
-        )
-    if request.method == 'POST' and ai_form.validate_on_submit():
-        sa.system_prompt = ai_form.system_prompt.data or None
-        sa.ai_model = ai_form.ai_model.data or None
-        sa.reasoning_effort = ai_form.reasoning_effort.data or None
-        sa.verbosity = ai_form.verbosity.data or None
-        db.session.commit()
-        flash('Paramètres enregistrés', 'success')
-        return redirect(url_for('settings.docx_schema_prompt_settings', page_id=page_id))
-    return render_template('settings/docx_schema_prompts.html', ai_form=ai_form, page=page)
+
+    sa_gen = SectionAISettings.get_for(f'docx_schema_{page_id}')
+    sa_impv = SectionAISettings.get_for(f'docx_schema_{page_id}_improve')
+    sa_impt = SectionAISettings.get_for(f'docx_schema_{page_id}_import')
+
+    if request.method == 'POST':
+        form_name = request.form.get('form_name')
+        target_map = {
+            'gen': sa_gen,
+            'impv': sa_impv,
+            'impt': sa_impt,
+        }
+        target_sa = target_map.get(form_name)
+        form = SectionAISettingsForm(request.form, obj=target_sa) if target_sa else None
+        if target_sa and form and form.validate():
+            target_sa.system_prompt = form.system_prompt.data or None
+            target_sa.ai_model = form.ai_model.data or None
+            target_sa.reasoning_effort = form.reasoning_effort.data or None
+            target_sa.verbosity = form.verbosity.data or None
+            db.session.commit()
+            flash('Paramètres enregistrés', 'success')
+            return redirect(url_for('settings.docx_schema_prompt_settings', page_id=page_id))
+
+    default_gen = (
+        "Tu es un assistant qui retourne une sortie strictement conforme au schéma JSON fourni."
+    )
+    default_impv = (
+        "Tu es un assistant qui améliore une sortie existante tout en respectant le schéma JSON fourni."
+    )
+    default_impt = (
+        "Tu es un assistant qui extrait des données d'un document et renvoie une sortie strictement conforme au schéma JSON fourni."
+    )
+
+    ai_form_gen = SectionAISettingsForm(obj=sa_gen)
+    ai_form_impv = SectionAISettingsForm(obj=sa_impv)
+    ai_form_impt = SectionAISettingsForm(obj=sa_impt)
+
+    if request.method == 'GET':
+        if not (sa_gen.system_prompt or '').strip():
+            ai_form_gen.system_prompt.data = default_gen
+        if not (sa_impv.system_prompt or '').strip():
+            ai_form_impv.system_prompt.data = default_impv
+        if not (sa_impt.system_prompt or '').strip():
+            ai_form_impt.system_prompt.data = default_impt
+
+    return render_template(
+        'settings/docx_schema_prompts.html',
+        ai_form_gen=ai_form_gen,
+        ai_form_impv=ai_form_impv,
+        ai_form_impt=ai_form_impt,
+        page=page,
+    )

--- a/src/app/templates/settings/docx_schema_prompts.html
+++ b/src/app/templates/settings/docx_schema_prompts.html
@@ -1,28 +1,103 @@
 {% extends "parametres.html" %}
 {% block parametres_content %}
   <h1 class="mb-3">{{ page.title }} – Paramètres IA</h1>
-  <form method="POST" action="{{ url_for('settings.docx_schema_prompt_settings', page_id=page.id) }}">
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-    <div class="mb-3">
-      <label class="form-label">{{ ai_form.system_prompt.label }}</label>
-      {{ ai_form.system_prompt(class_='form-control font-monospace', rows=12) }}
-    </div>
-    <div class="row g-3">
-      <div class="col-md-4">
-        <label class="form-label">{{ ai_form.ai_model.label }}</label>
-        {{ ai_form.ai_model(class_='form-select') }}
+  <div class="card mb-4">
+    <div class="card-header bg-light"><strong>Paramètres IA</strong></div>
+    <div class="card-body">
+      <ul class="nav nav-tabs" id="schemaTabs" role="tablist">
+        <li class="nav-item" role="presentation">
+          <button class="nav-link active" id="tab-gen" data-bs-toggle="tab" data-bs-target="#pane-gen" type="button" role="tab">Génération</button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="tab-impv" data-bs-toggle="tab" data-bs-target="#pane-impv" type="button" role="tab">Amélioration</button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="tab-impt" data-bs-toggle="tab" data-bs-target="#pane-impt" type="button" role="tab">Importation</button>
+        </li>
+      </ul>
+      <div class="tab-content pt-3">
+        <div class="tab-pane fade show active" id="pane-gen" role="tabpanel">
+          <form method="POST" action="{{ url_for('settings.docx_schema_prompt_settings', page_id=page.id) }}">
+            <input type="hidden" name="form_name" value="gen"/>
+            {{ ai_form_gen.csrf_token }}
+            <div class="mb-3">
+              <label class="form-label">{{ ai_form_gen.system_prompt.label }}</label>
+              {{ ai_form_gen.system_prompt(class_='form-control font-monospace', rows=12) }}
+            </div>
+            <div class="row g-3">
+              <div class="col-md-4">
+                <label class="form-label">{{ ai_form_gen.ai_model.label }}</label>
+                {{ ai_form_gen.ai_model(class_='form-select') }}
+              </div>
+              <div class="col-md-4">
+                <label class="form-label">{{ ai_form_gen.reasoning_effort.label }}</label>
+                {{ ai_form_gen.reasoning_effort(class_='form-select') }}
+              </div>
+              <div class="col-md-4">
+                <label class="form-label">{{ ai_form_gen.verbosity.label }}</label>
+                {{ ai_form_gen.verbosity(class_='form-select') }}
+              </div>
+            </div>
+            <div class="mt-3 text-end">
+              <button class="btn btn-primary" type="submit">Enregistrer (Génération)</button>
+            </div>
+          </form>
+        </div>
+        <div class="tab-pane fade" id="pane-impv" role="tabpanel">
+          <form method="POST" action="{{ url_for('settings.docx_schema_prompt_settings', page_id=page.id) }}">
+            <input type="hidden" name="form_name" value="impv"/>
+            {{ ai_form_impv.csrf_token }}
+            <div class="mb-3">
+              <label class="form-label">{{ ai_form_impv.system_prompt.label }}</label>
+              {{ ai_form_impv.system_prompt(class_='form-control font-monospace', rows=12) }}
+            </div>
+            <div class="row g-3">
+              <div class="col-md-4">
+                <label class="form-label">{{ ai_form_impv.ai_model.label }}</label>
+                {{ ai_form_impv.ai_model(class_='form-select') }}
+              </div>
+              <div class="col-md-4">
+                <label class="form-label">{{ ai_form_impv.reasoning_effort.label }}</label>
+                {{ ai_form_impv.reasoning_effort(class_='form-select') }}
+              </div>
+              <div class="col-md-4">
+                <label class="form-label">{{ ai_form_impv.verbosity.label }}</label>
+                {{ ai_form_impv.verbosity(class_='form-select') }}
+              </div>
+            </div>
+            <div class="mt-3 text-end">
+              <button class="btn btn-primary" type="submit">Enregistrer (Amélioration)</button>
+            </div>
+          </form>
+        </div>
+        <div class="tab-pane fade" id="pane-impt" role="tabpanel">
+          <form method="POST" action="{{ url_for('settings.docx_schema_prompt_settings', page_id=page.id) }}">
+            <input type="hidden" name="form_name" value="impt"/>
+            {{ ai_form_impt.csrf_token }}
+            <div class="mb-3">
+              <label class="form-label">{{ ai_form_impt.system_prompt.label }}</label>
+              {{ ai_form_impt.system_prompt(class_='form-control font-monospace', rows=12) }}
+            </div>
+            <div class="row g-3">
+              <div class="col-md-4">
+                <label class="form-label">{{ ai_form_impt.ai_model.label }}</label>
+                {{ ai_form_impt.ai_model(class_='form-select') }}
+              </div>
+              <div class="col-md-4">
+                <label class="form-label">{{ ai_form_impt.reasoning_effort.label }}</label>
+                {{ ai_form_impt.reasoning_effort(class_='form-select') }}
+              </div>
+              <div class="col-md-4">
+                <label class="form-label">{{ ai_form_impt.verbosity.label }}</label>
+                {{ ai_form_impt.verbosity(class_='form-select') }}
+              </div>
+            </div>
+            <div class="mt-3 text-end">
+              <button class="btn btn-primary" type="submit">Enregistrer (Importation)</button>
+            </div>
+          </form>
+        </div>
       </div>
-      <div class="col-md-4">
-        <label class="form-label">{{ ai_form.reasoning_effort.label }}</label>
-        {{ ai_form.reasoning_effort(class_='form-select') }}
-      </div>
-      <div class="col-md-4">
-        <label class="form-label">{{ ai_form.verbosity.label }}</label>
-        {{ ai_form.verbosity(class_='form-select') }}
-      </div>
     </div>
-    <div class="mt-3 text-end">
-      <button class="btn btn-primary" type="submit">Enregistrer</button>
-    </div>
-  </form>
+  </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add generation, improvement and importation settings tabs for each DOCX schema
- Update schema prompt settings route to handle multiple sections and defaults
- Extend tests for new schema prompt tabs

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6329bbc008322a9159c2a37a1245d