### PR TITLE
Align docx schema preview with plan-cadre styling

### DIFF
--- a/src/app/templates/docx_schema_preview.html
+++ b/src/app/templates/docx_schema_preview.html
@@ -1,6 +1,11 @@
 {% extends "base.html" %}
 {% block title %}{{ page.title }}{% endblock %}
 
+{% block head %}
+  {{ super() }}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/view_plan_cadre.css') }}">
+{% endblock %}
+
 {% block content %}
 <div class="container mt-4">
   <h1 id="schemaPageTitle">{{ page.title }}</h1>
@@ -26,9 +31,20 @@
 
   <section class="mb-4">
     <h2 class="h4 mb-3">Plan cadre</h2>
-    <form id="planCadreForm" class="d-flex flex-column gap-3"></form>
-    <button type="button" id="planCadreSaveBtn" class="btn btn-primary mt-2">Enregistrer</button>
+    <form id="planCadreForm">
+      <div class="accordion" id="planCadreAccordion"></div>
+    </form>
   </section>
+</div>
+
+<div id="actionBar" class="fixed-bottom bg-white border-top d-none shadow">
+  <div class="container py-2">
+    <div class="row g-2">
+      <div class="col">
+        <button type="button" id="floatingSaveBtn" class="btn btn-primary w-100">Enregistrer</button>
+      </div>
+    </div>
+  </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script>
@@ -36,6 +52,9 @@ document.addEventListener('DOMContentLoaded', () => {
   let schemaData = {{ page.json_schema | tojson }};
   const markdownData = {{ page.markdown_content | tojson }};
   const planFormEl = document.getElementById('planCadreForm');
+  const accordionRoot = document.getElementById('planCadreAccordion');
+  const actionBar = document.getElementById('actionBar');
+  const floatingSaveBtn = document.getElementById('floatingSaveBtn');
   let markdownOrderMap = {};
   const normalizedMarkdown = normalizeName(markdownData || '');
   function normalizeName(str) {
@@ -159,7 +178,20 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     return walk(node);
   }
-  function renderPlanCadreForm(schema, parent, path='root') {
+  function showActionBar() {
+    if (actionBar && actionBar.classList.contains('d-none')) {
+      actionBar.classList.remove('d-none');
+      document.body.classList.add('with-action-bar');
+    }
+  }
+  if (floatingSaveBtn) {
+    floatingSaveBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      actionBar.classList.add('d-none');
+      document.body.classList.remove('with-action-bar');
+    });
+  }
+  function renderPlanCadreForm(schema, parent, path='root', depth=0) {
     if (!schema || !parent) return;
     if (schema.type === 'object' && schema.properties) {
       const entries = Object.entries(schema.properties);
@@ -173,100 +205,119 @@ document.addEventListener('DOMContentLoaded', () => {
         const posB = ib !== -1 ? ib : getMarkdownIndex(nameB);
         return posA - posB;
       });
-      const container = path === 'root' ? parent : document.createElement('div');
-      if (path !== 'root') {
-        container.className = 'border rounded p-2 mb-3';
-        const legend = document.createElement('h6');
-        legend.textContent = schema.title || path;
-        legend.className = 'fw-bold';
-        container.appendChild(legend);
-      }
-      for (const [key, prop] of entries) {
-        const childName = normalizeName(prop.title || key);
-        const childPath = path === 'root' ? childName : `${path}.${childName}`;
-        renderPlanCadreForm(prop, container, childPath);
-      }
-      if (path !== 'root') parent.appendChild(container);
+      entries.forEach(([key, prop], idx) => {
+        const sectionId = `${path.replace(/\./g, '-')}-${idx}`;
+        const item = document.createElement('div');
+        item.className = 'accordion-item';
+        const header = document.createElement('h2');
+        header.className = 'accordion-header d-flex';
+        const btn = document.createElement('button');
+        btn.className = `accordion-button ${depth > 0 ? 'collapsed' : ''} ${depth === 0 ? 'bg-light' : ''} flex-grow-1`;
+        btn.type = 'button';
+        btn.setAttribute('data-bs-toggle', 'collapse');
+        btn.setAttribute('data-bs-target', `#collapse-${sectionId}`);
+        btn.setAttribute('aria-expanded', depth > 0 ? 'false' : 'true');
+        btn.textContent = prop.title || key;
+        header.appendChild(btn);
+        const magicBtn = document.createElement('button');
+        magicBtn.type = 'button';
+        magicBtn.className = 'btn btn-sm btn-outline-primary ms-2 magic-generate';
+        magicBtn.setAttribute('data-target-column', path === 'root' ? key : `${path}.${key}`);
+        magicBtn.title = 'Améliorer uniquement cette section';
+        magicBtn.innerHTML = '<i class="bi bi-magic"></i>';
+        header.appendChild(magicBtn);
+        item.appendChild(header);
+        const collapse = document.createElement('div');
+        collapse.id = `collapse-${sectionId}`;
+        collapse.className = `accordion-collapse collapse ${depth === 0 ? 'show' : ''}`;
+        if (depth === 0) collapse.setAttribute('data-bs-parent', '#planCadreAccordion');
+        const body = document.createElement('div');
+        body.className = 'accordion-body';
+        collapse.appendChild(body);
+        item.appendChild(collapse);
+        parent.appendChild(item);
+        renderPlanCadreForm(prop, body, path === 'root' ? key : `${path}.${key}`, depth + 1);
+      });
       return;
     }
     if (schema.type === 'array' && schema.items) {
       const container = document.createElement('div');
       container.className = 'mb-3';
-
       const label = document.createElement('label');
-      label.className = 'form-label';
+      label.className = 'form-label fw-bold';
       label.textContent = schema.title || path;
       container.appendChild(label);
-
       const list = document.createElement('div');
       list.className = 'd-flex flex-column gap-2';
       container.appendChild(list);
-
-      const itemName = normalizeName(schema.items.title || schema.title || path);
-      const itemPath = path === 'root' ? itemName : `${path}.${itemName}`;
-
       function addItem() {
-        if (schema.items.type === 'object') {
-          const wrapper = document.createElement('div');
-          wrapper.className = 'border rounded p-2 position-relative';
-          renderPlanCadreForm(schema.items, wrapper, itemPath);
-          const btn = document.createElement('button');
-          btn.type = 'button';
-          btn.className = 'btn btn-outline-danger btn-sm position-absolute top-0 end-0 remove-form-array-item';
-          btn.innerHTML = '<i class="bi bi-x"></i>';
-          btn.addEventListener('click', () => wrapper.remove());
-          wrapper.appendChild(btn);
-          list.appendChild(wrapper);
+        const wrapper = document.createElement('div');
+        wrapper.className = 'border rounded p-2 position-relative';
+        if (schema.items.type === 'object' && schema.items.properties && schema.items.properties.title && schema.items.properties.description) {
+          const titleInput = document.createElement('input');
+          titleInput.className = 'form-control fw-bold mb-1';
+          titleInput.placeholder = 'Titre';
+          wrapper.appendChild(titleInput);
+          const descTextarea = document.createElement('textarea');
+          descTextarea.className = 'form-control';
+          descTextarea.placeholder = 'Description';
+          wrapper.appendChild(descTextarea);
+        } else if (schema.items.type === 'object') {
+          renderPlanCadreForm(schema.items, wrapper, path + '[]', depth + 1);
         } else {
-          const wrapper = document.createElement('div');
-          wrapper.className = 'input-group';
           const input = document.createElement('input');
           input.className = 'form-control';
           input.name = `${path}[]`;
           wrapper.appendChild(input);
-          const btn = document.createElement('button');
-          btn.type = 'button';
-          btn.className = 'btn btn-outline-danger remove-form-array-item';
-          btn.innerHTML = '<i class="bi bi-x"></i>';
-          btn.addEventListener('click', () => wrapper.remove());
-          wrapper.appendChild(btn);
-          list.appendChild(wrapper);
         }
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'btn btn-outline-danger btn-sm position-absolute top-0 end-0 remove-form-array-item';
+        btn.innerHTML = '<i class="bi bi-x"></i>';
+        btn.addEventListener('click', () => { wrapper.remove(); showActionBar(); });
+        wrapper.appendChild(btn);
+        list.appendChild(wrapper);
+        showActionBar();
       }
-
       const addBtn = document.createElement('button');
       addBtn.type = 'button';
       addBtn.className = 'btn btn-outline-primary btn-sm add-form-array-item';
       addBtn.textContent = 'Ajouter';
       addBtn.addEventListener('click', addItem);
       container.appendChild(addBtn);
-
       parent.appendChild(container);
       addItem();
       return;
     }
-
     const field = document.createElement('div');
     field.className = 'mb-3';
     const label = document.createElement('label');
-    label.className = 'form-label';
-    label.setAttribute('for', path);
+    label.className = 'form-label fw-bold';
     label.textContent = schema.title || path;
-    const input = document.createElement('input');
-    input.className = 'form-control';
-    input.id = path;
-    input.name = path;
-    if (schema.type === 'number' || schema.type === 'integer') input.type = 'number';
-    else input.type = 'text';
     field.appendChild(label);
-    field.appendChild(input);
+    if (schema.type === 'string' && (path.toLowerCase().includes('description'))) {
+      const textarea = document.createElement('textarea');
+      textarea.className = 'form-control';
+      textarea.name = path;
+      field.appendChild(textarea);
+    } else {
+      const input = document.createElement('input');
+      input.className = 'form-control';
+      input.name = path;
+      if (schema.type === 'number' || schema.type === 'integer') input.type = 'number';
+      else input.type = 'text';
+      field.appendChild(input);
+    }
     parent.appendChild(field);
   }
   let currentSchema = normalizePlanSchema(schemaData);
   markdownOrderMap = buildMarkdownOrderMap(markdownData);
+  if (accordionRoot) {
+    accordionRoot.innerHTML = '';
+    renderPlanCadreForm(currentSchema, accordionRoot);
+  }
   if (planFormEl) {
-    planFormEl.innerHTML = '';
-    renderPlanCadreForm(currentSchema, planFormEl);
+    planFormEl.addEventListener('input', showActionBar);
   }
 });
 </script>

--- a/tests/test_docx_to_schema_ui.py
+++ b/tests/test_docx_to_schema_ui.py
@@ -103,6 +103,8 @@ def test_docx_to_schema_validate_endpoint(app, client):
     assert resp.status_code == 200
     assert b'Sample' in resp.data
     assert b'id="planCadreForm"' in resp.data
+    assert b'id="actionBar"' in resp.data
+    assert b'id="planCadreAccordion"' in resp.data
     assert b'id="schemaEditBtn"' not in resp.data
     assert b'id="schemaResultMarkdown"' not in resp.data
     assert b'id="schemaAccordion"' not in resp.data
@@ -275,7 +277,8 @@ def test_docx_schema_preview_plan_form(app, client):
     resp = client.get(f'/docx_schema/{page_id}')
     data = resp.data
     assert b'id="planCadreForm"' in data
-    assert b'id="planCadreSaveBtn"' in data
+    assert b'id="actionBar"' in data
+    assert b'id="floatingSaveBtn"' in data
     assert b'add-form-array-item' in data
 
 


### PR DESCRIPTION
## Summary
- Harmonize docx schema preview page with plan-cadre styling using shared CSS and accordion layout
- Add floating save bar and section-level improvement controls
- Update tests for new UI elements and array item controls

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6342a71548322a0101b88545ec043