### PR TITLE
feat: enable choosing parent entity for inherited schemas

### DIFF
--- a/src/app/routes/settings.py
+++ b/src/app/routes/settings.py
@@ -248,11 +248,15 @@ def create_schema_link():
     if not (src_page and tgt_page and src_ptr and tgt_ptr):
         return jsonify({'error': 'Champs requis manquants.'}), 400
     # Validation simple des pointeurs: autoriser '#/' ou '/'
-    if not (src_ptr.startswith('#/') or src_ptr.startswith('/')):
-        return jsonify({'error': 'source_pointer doit être un JSON Pointer (#/...)'}), 400
-    if not (tgt_ptr.startswith('#/') or tgt_ptr.startswith('/')):
-        return jsonify({'error': 'target_pointer doit être un JSON Pointer (#/...)'}), 400
-    # Normaliser sur format '#/'
+    def _is_valid_ptr(p: str) -> bool:
+        return p == '#' or p.startswith('#/') or p.startswith('/')
+
+    if not _is_valid_ptr(src_ptr):
+        return jsonify({'error': 'source_pointer doit être un JSON Pointer (#/...) ou #'}), 400
+    if not _is_valid_ptr(tgt_ptr):
+        return jsonify({'error': 'target_pointer doit être un JSON Pointer (#/...) ou #'}), 400
+
+    # Normaliser sur format commençant par '#'
     if src_ptr.startswith('/'):
         src_ptr = '#' + src_ptr
     if tgt_ptr.startswith('/'):

--- a/src/app/templates/docx_schema_preview.html
+++ b/src/app/templates/docx_schema_preview.html
@@ -46,6 +46,7 @@
   </div>
 
   <section class="mb-4">
+    <div id="parentEntryPicker" class="mb-3"></div>
     <form id="planCadreForm">
       <div class="accordion" id="planCadreAccordion"></div>
     </form>
@@ -425,6 +426,35 @@ document.addEventListener('DOMContentLoaded', () => {
       return out;
     } catch { return []; }
   }
+  function getValueAtPointer(obj, ptr){
+    try {
+      const path = pointerToPath(ptr);
+      let cur = obj;
+      for (const p of path){
+        if (cur == null) return undefined;
+        cur = cur[p];
+      }
+      return cur;
+    } catch { return undefined; }
+  }
+  function setDataAtPointer(root, ptr, value){
+    const path = pointerToPath(ptr);
+    let cur = root;
+    for (let i=0;i<path.length-1;i++){
+      const k = path[i];
+      if (cur[k] === undefined) cur[k] = (typeof path[i+1] === 'number') ? [] : {};
+      cur = cur[k];
+    }
+    if (path.length){
+      cur[path[path.length-1]] = value;
+    }
+  }
+  function disableField(ptr){
+    const field = document.querySelector(`[data-pointer="${CSS.escape(ptr)}"]`);
+    if (!field) return;
+    field.querySelectorAll('input, textarea, select').forEach(el => { el.disabled = true; });
+    field.querySelectorAll('.add-item-btn, .remove-item-btn').forEach(btn => { btn.disabled = true; btn.style.display = 'none'; });
+  }
   function setDeepAtPath(obj, pathArr, value){
     let cur = obj;
     for (let i=0;i<pathArr.length;i++){
@@ -539,6 +569,47 @@ document.addEventListener('DOMContentLoaded', () => {
     if (typeof data === 'number') input.value = String(data);
     else if (typeof data === 'string') input.value = data;
     else input.value = JSON.stringify(data);
+  }
+  function enhanceLinkedFields(){
+    const fields = document.querySelectorAll('[data-pointer]');
+    fields.forEach((holder) => {
+      const ptr = holder.getAttribute('data-pointer');
+      const link = getLinkForPointer(ptr);
+      if (!link || link.relation_type !== 'utilise') return;
+      const el = holder.querySelector('input.form-control');
+      if (el && (el.type === 'text' || el.type === 'number')) {
+        turnInputIntoSelect(holder, el, ptr, {});
+      }
+    });
+  }
+  async function applyParent(parentId){
+    accordionRoot.innerHTML = '';
+    renderPlanCadreForm(currentSchema, accordionRoot, 'root', 0, {}, '#');
+    if (initialEntryData) {
+      try { prepopulateFromData(currentSchema, initialEntryData, '#'); } catch {}
+    }
+    enhanceLinkedFields();
+    if (!parentId || !rootLink) return;
+    try {
+      const r = await fetch(`/docx_schema/${rootLink.target_page_id}/entries`);
+      if (!r.ok) return;
+      const j = await r.json();
+      const entry = (j.entries || []).find(e => e.id === parentId);
+      if (!entry) return;
+      const inherited = {};
+      for (const [ptr, link] of Object.entries(schemaLinksByPointer)){
+        if (link.relation_type === 'herite_de' && ptr !== '#'){
+          const v = getValueAtPointer(entry.data, link.target_pointer);
+          if (v !== undefined) setDataAtPointer(inherited, ptr, v);
+        }
+      }
+      prepopulateFromData(currentSchema, inherited, '#');
+      for (const [ptr, link] of Object.entries(schemaLinksByPointer)){
+        if (link.relation_type === 'herite_de' && ptr !== '#'){
+          disableField(ptr);
+        }
+      }
+    } catch {}
   }
   function escapeHtml(s){ return (s||'').toString().replace(/[&<>"']/g, c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c])); }
   let lastHighlighted = null;
@@ -1140,20 +1211,15 @@ document.addEventListener('DOMContentLoaded', () => {
   if (initialEntryData) {
     try { prepopulateFromData(currentSchema, initialEntryData, '#'); } catch (e) { console.warn('Pré-remplissage échoué', e); }
   }
-  // Load links after render and enhance fields accordingly
+  // Load links after render, enhance fields and setup root inheritance selector
+  let rootLink = null;
   loadSchemaLinks().then(() => {
-    // Post-process: find fields that have links and turn them into selects
-    const fields = document.querySelectorAll('[data-pointer]');
-    fields.forEach((holder) => {
-      const ptr = holder.getAttribute('data-pointer');
-      const link = getLinkForPointer(ptr);
-      if (!link || !['utilise','herite_de'].includes(link.relation_type)) return;
-      // Find a direct input/textarea child to replace
-      const el = holder.querySelector('input.form-control');
-      if (el && (el.type === 'text' || el.type === 'number')) {
-        turnInputIntoSelect(holder, el, ptr, {});
-      }
-    });
+    rootLink = schemaLinksByPointer['#'] || null;
+    if (rootLink && rootLink.relation_type === 'herite_de') {
+      const picker = document.getElementById('parentEntryPicker');
+      ensureEntryPicker(picker, rootLink, (id) => { applyParent(id); });
+    }
+    enhanceLinkedFields();
   });
   if (planFormEl) {
     planFormEl.addEventListener('input', showActionBar);

--- a/src/app/templates/settings/data_schemas.html
+++ b/src/app/templates/settings/data_schemas.html
@@ -4,7 +4,7 @@
 
 {% block parametres_content %}
 <h2 class="mb-3">Schémas de données – Lier des éléments</h2>
-<p class="text-muted">Créez des liens entre éléments de schémas (hérite de, dérive de, équivalent à, utilise). Les pointeurs utilisent le format JSON Pointer (ex.: <code>#/properties/chapitres/items</code>).</p>
+<p class="text-muted">Créez des liens entre éléments de schémas (hérite de, dérive de, équivalent à, utilise). Les pointeurs utilisent le format JSON Pointer (ex.: <code>#/properties/chapitres/items</code> ou <code>#</code> pour la racine).</p>
 
 <div class="card mb-3">
   <div class="card-header">
@@ -34,7 +34,7 @@
   <div class="col-12 col-lg-3">
     <label class="form-label">Chemin (JSON Pointer)</label>
     <div class="input-group">
-      <input id="srcPtr" class="form-control" placeholder="#/properties/...">
+      <input id="srcPtr" class="form-control" placeholder="# ou #/properties/...">
       <button class="btn btn-outline-secondary" type="button" id="pickSrc">Choisir</button>
     </div>
   </div>
@@ -59,7 +59,7 @@
   <div class="col-12 col-lg-3">
     <label class="form-label">Chemin cible</label>
     <div class="input-group">
-      <input id="tgtPtr" class="form-control" placeholder="#/properties/...">
+      <input id="tgtPtr" class="form-control" placeholder="# ou #/properties/...">
       <button class="btn btn-outline-secondary" type="button" id="pickTgt">Choisir</button>
     </div>
   </div>
@@ -171,7 +171,13 @@
         container.appendChild(row);
       }
     }
-    walk(schema, basePtr, root);
+    // racine
+    const rootRow = nodeRow(`${schema.title || 'Racine'} (racine)`, basePtr);
+    root.appendChild(rootRow);
+    const childContainer = document.createElement('div');
+    childContainer.className = 'ms-3 border-start ps-2';
+    root.appendChild(childContainer);
+    walk(schema, basePtr, childContainer);
     return root;
   }
   function filterTree(root, q) {

--- a/tests/test_data_schema_links.py
+++ b/tests/test_data_schema_links.py
@@ -79,3 +79,21 @@ def test_create_and_list_schema_links(app, client):
     ids = [l['id'] for l in r4.get_json()['links']]
     assert lid not in ids
 
+
+def test_create_link_with_root_pointer(app, client):
+    admin_id = create_admin(app)
+    _login(client, admin_id)
+    p1, p2 = create_schema_pages(app)
+    payload = {
+        'source_page_id': p1,
+        'source_pointer': '#',
+        'relation_type': 'herite_de',
+        'target_page_id': p2,
+        'target_pointer': '#'
+    }
+    r = client.post('/settings/schemas/links', json=payload)
+    assert r.status_code == 201
+    link = r.get_json()['link']
+    assert link['source_pointer'] == '#'
+    assert link['target_pointer'] == '#'
+

--- a/tests/test_docx_schema_root_inheritance.py
+++ b/tests/test_docx_schema_root_inheritance.py
@@ -1,0 +1,62 @@
+from src.app.models import DocxSchemaPage, DocxSchemaEntry, DataSchemaLink, User
+from werkzeug.security import generate_password_hash
+from src.app import db
+
+
+def _login(client, user_id):
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(user_id)
+        sess['_fresh'] = True
+
+
+
+def create_admin(app):
+    with app.app_context():
+        admin = User(
+            username='admin_root_inherit',
+            password=generate_password_hash('pw'),
+            role='admin',
+            is_first_connexion=False,
+            openai_key='sk',
+        )
+        db.session.add(admin)
+        db.session.commit()
+        return admin.id
+
+
+def test_root_inheritance_page_has_parent_picker(app, client):
+    admin_id = create_admin(app)
+    _login(client, admin_id)
+    with app.app_context():
+        parent = DocxSchemaPage(title='Parent', json_schema={'title': 'P', 'type': 'object', 'properties': {
+            'name': {'type': 'string'}
+        }})
+        db.session.add(parent); db.session.commit()
+        parent_id = parent.id
+        pe = DocxSchemaEntry(page_id=parent_id, data={'name': 'A'})
+        db.session.add(pe)
+        child = DocxSchemaPage(title='Child', json_schema={'title': 'C', 'type': 'object', 'properties': {
+            'name': {'type': 'string'}
+        }})
+        db.session.add(child); db.session.commit()
+        child_id = child.id
+        link_root = DataSchemaLink(
+            source_page_id=child_id,
+            source_pointer='#',
+            relation_type='herite_de',
+            target_page_id=parent_id,
+            target_pointer='#'
+        )
+        link_field = DataSchemaLink(
+            source_page_id=child_id,
+            source_pointer='#/properties/name',
+            relation_type='herite_de',
+            target_page_id=parent_id,
+            target_pointer='#/properties/name'
+        )
+        db.session.add_all([link_root, link_field]); db.session.commit()
+    resp = client.get(f'/docx_schema/{child_id}')
+    assert resp.status_code == 200
+    assert b'id="parentEntryPicker"' in resp.data
+    links = client.get(f'/docx_schema/{child_id}/links').get_json()['links']
+    assert any(l['source_pointer'] == '#' for l in links)


### PR DESCRIPTION
## Summary
- add parent selection dropdown when a schema inherits from another schema
- auto-fill and lock inherited fields based on chosen parent entry
- test root-level inheritance UI elements
- allow root pointers when linking schemas so whole pages can relate
- expose root node in schema pointer picker and mention it in helper text
- test creating schema links using the root pointer

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b78b25e09883229930d62bc3485370